### PR TITLE
Allow for signing pipelineruns

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -26,12 +26,7 @@ import (
 )
 
 type Signable interface {
-	// TODO: We may want to consider refactoring ExtractObjects to take interface{}, or
-	// some generic k8s type that contians the metadata attribute, for example. It does
-	// not make sense for the TaskRunArtifact to implement ExtractObjectsFromPipelineRun
-	// just to comply with this interface.
-	ExtractObjects(tr *v1beta1.TaskRun) []interface{}
-	ExtractObjectsFromPipelineRun(tr *v1beta1.PipelineRun) []interface{}
+	ExtractObjects(obj interface{}) []interface{}
 	StorageBackend(cfg config.Config) sets.String
 	Signer(cfg config.Config) string
 	PayloadFormat(cfg config.Config) formats.PayloadType
@@ -49,12 +44,9 @@ func (ta *TaskRunArtifact) Key(obj interface{}) string {
 	return "taskrun-" + string(tr.UID)
 }
 
-func (ta *TaskRunArtifact) ExtractObjects(tr *v1beta1.TaskRun) []interface{} {
+func (ta *TaskRunArtifact) ExtractObjects(obj interface{}) []interface{} {
+	tr := obj.(*v1beta1.TaskRun)
 	return []interface{}{tr}
-}
-
-func (ta *TaskRunArtifact) ExtractObjectsFromPipelineRun(pr *v1beta1.PipelineRun) []interface{} {
-	return make([]interface{}, 0)
 }
 
 func (ta *TaskRunArtifact) Type() string {
@@ -86,11 +78,8 @@ func (pa *PipelineRunArtifact) Key(obj interface{}) string {
 	return "pipelinerun-" + string(pr.UID)
 }
 
-func (pa *PipelineRunArtifact) ExtractObjects(tr *v1beta1.TaskRun) []interface{} {
-	return make([]interface{}, 0)
-}
-
-func (pa *PipelineRunArtifact) ExtractObjectsFromPipelineRun(pr *v1beta1.PipelineRun) []interface{} {
+func (pa *PipelineRunArtifact) ExtractObjects(obj interface{}) []interface{} {
+	pr := obj.(*v1beta1.PipelineRun)
 	return []interface{}{pr}
 }
 
@@ -124,7 +113,8 @@ type image struct {
 	digest string
 }
 
-func (oa *OCIArtifact) ExtractObjects(tr *v1beta1.TaskRun) []interface{} {
+func (oa *OCIArtifact) ExtractObjects(obj interface{}) []interface{} {
+	tr := obj.(*v1beta1.TaskRun)
 	imageResourceNames := map[string]*image{}
 	if tr.Status.TaskSpec != nil && tr.Status.TaskSpec.Resources != nil {
 		for _, output := range tr.Status.TaskSpec.Resources.Outputs {
@@ -162,10 +152,6 @@ func (oa *OCIArtifact) ExtractObjects(tr *v1beta1.TaskRun) []interface{} {
 	objs = append(objs, resultImages...)
 
 	return objs
-}
-
-func (oa *OCIArtifact) ExtractObjectsFromPipelineRun(pr *v1beta1.PipelineRun) []interface{} {
-	return make([]interface{}, 0)
 }
 
 func ExtractOCIImagesFromResults(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []interface{} {

--- a/pkg/chains/formats/tekton/tekton.go
+++ b/pkg/chains/formats/tekton/tekton.go
@@ -31,14 +31,14 @@ func NewFormatter() (formats.Payloader, error) {
 
 // CreatePayload implements the Payloader interface.
 func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
-
 	switch v := obj.(type) {
 	case *v1beta1.TaskRun:
+		return v.Status, nil
+	case *v1beta1.PipelineRun:
 		return v.Status, nil
 	default:
 		return nil, fmt.Errorf("unsupported type %s", v)
 	}
-
 }
 
 func (i *Tekton) Type() formats.PayloadType {

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -1,0 +1,158 @@
+package objects
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+type Annotation struct {
+	Err   error
+	Value string
+	Ok    bool
+}
+
+// Represents a generic K8s object
+// This isn't meant to be a final implementation, just one approach
+// Commented out methods will be required for other storage mechanisms,
+//  but we're focused on Tekton for now
+type K8sObject interface {
+	GetName() string
+	GetNamespace() string
+	GetKind() string
+	GetAnnotation(annotation string) *Annotation
+	GetLatestAnnotation(annotation string) *Annotation
+	GetObject() interface{}
+	Patch(patchBytes []byte) error
+	// GetUID() string
+	// GetGroupVersion() string
+	// GetStatus() interface{}
+}
+
+type TaskRunObject struct {
+	tr        *v1beta1.TaskRun
+	clientSet versioned.Interface
+	ctx       context.Context
+}
+
+func NewTaskRunObject(tr *v1beta1.TaskRun, clientSet versioned.Interface, ctx context.Context) *TaskRunObject {
+	return &TaskRunObject{
+		tr:        tr,
+		clientSet: clientSet,
+		ctx:       ctx,
+	}
+}
+
+func (tro *TaskRunObject) GetName() string {
+	return tro.tr.Name
+}
+
+func (tro *TaskRunObject) GetNamespace() string {
+	return tro.tr.Namespace
+}
+
+func (tro *TaskRunObject) GetKind() string {
+	return tro.tr.Kind
+}
+
+func (tro *TaskRunObject) GetAnnotation(annotation string) *Annotation {
+	val, ok := tro.tr.Annotations[annotation]
+	return &Annotation{
+		Err:   nil,
+		Value: val,
+		Ok:    ok,
+	}
+}
+
+func (tro *TaskRunObject) GetLatestAnnotation(annotation string) *Annotation {
+	tr, err := tro.clientSet.TektonV1beta1().TaskRuns(tro.tr.Namespace).Get(tro.ctx, tro.tr.Name, v1.GetOptions{})
+	if err != nil {
+		return &Annotation{
+			Err:   fmt.Errorf("error retrieving taskrun: %s", err),
+			Value: "",
+			Ok:    false,
+		}
+	}
+	val, ok := tr.Annotations[annotation]
+	return &Annotation{
+		Err:   nil,
+		Value: val,
+		Ok:    ok,
+	}
+}
+
+func (tro *TaskRunObject) GetObject() interface{} {
+	return tro.tr
+}
+
+func (tro *TaskRunObject) Patch(patchBytes []byte) error {
+	_, err := tro.clientSet.TektonV1beta1().TaskRuns(tro.tr.Namespace).Patch(
+		tro.ctx, tro.tr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
+	return err
+}
+
+type PipelineRunObject struct {
+	pr        *v1beta1.PipelineRun
+	clientSet versioned.Interface
+	ctx       context.Context
+}
+
+func NewPipelineRunObject(pr *v1beta1.PipelineRun, clientSet versioned.Interface, ctx context.Context) *PipelineRunObject {
+	return &PipelineRunObject{
+		pr:        pr,
+		clientSet: clientSet,
+		ctx:       ctx,
+	}
+}
+
+func (pro *PipelineRunObject) GetName() string {
+	return pro.pr.Name
+}
+
+func (pro *PipelineRunObject) GetNamespace() string {
+	return pro.pr.Namespace
+}
+
+func (pro *PipelineRunObject) GetKind() string {
+	return pro.pr.Kind
+}
+
+func (pro *PipelineRunObject) GetAnnotation(annotation string) *Annotation {
+	val, ok := pro.pr.Annotations[annotation]
+	return &Annotation{
+		Err:   nil,
+		Value: val,
+		Ok:    ok,
+	}
+}
+
+func (pro *PipelineRunObject) GetLatestAnnotation(annotation string) *Annotation {
+	tr, err := pro.clientSet.TektonV1beta1().PipelineRuns(pro.pr.Namespace).Get(pro.ctx, pro.pr.Name, v1.GetOptions{})
+	if err != nil {
+		return &Annotation{
+			Err:   fmt.Errorf("error retrieving pipelinerun: %s", err),
+			Value: "",
+			Ok:    false,
+		}
+	}
+	val, ok := tr.Annotations[annotation]
+	return &Annotation{
+		Err:   nil,
+		Value: val,
+		Ok:    ok,
+	}
+}
+
+func (pro *PipelineRunObject) GetObject() interface{} {
+	return pro.pr
+}
+
+func (pro *PipelineRunObject) Patch(patchBytes []byte) error {
+	_, err := pro.clientSet.TektonV1beta1().PipelineRuns(pro.pr.Namespace).Patch(
+		pro.ctx, pro.pr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
+	return err
+}

--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -23,9 +23,9 @@ import (
 	"github.com/sigstore/rekor/pkg/generated/client"
 	"github.com/sigstore/rekor/pkg/generated/models"
 	"github.com/sigstore/sigstore/pkg/cryptoutils"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 )
 
@@ -86,7 +86,7 @@ var getRekor = func(url string, l *zap.SugaredLogger) (rekorClient, error) {
 	}, nil
 }
 
-func shouldUploadTlog(cfg config.Config, tr *v1beta1.TaskRun) bool {
+func shouldUploadTlog(cfg config.Config, obj objects.K8sObject) bool {
 	// if transparency isn't enabled, return false
 	if !cfg.Transparency.Enabled {
 		return false
@@ -97,9 +97,12 @@ func shouldUploadTlog(cfg config.Config, tr *v1beta1.TaskRun) bool {
 	}
 
 	// Already uploaded, don't do it again
-	if _, ok := tr.Annotations[ChainsTransparencyAnnotation]; ok {
+	ann := obj.GetAnnotation(ChainsTransparencyAnnotation)
+	if ann.Ok {
 		return false
 	}
+
 	// verify the annotation
-	return tr.Annotations[RekorAnnotation] == "true"
+	ann = obj.GetAnnotation(RekorAnnotation)
+	return ann.Value == "true"
 }

--- a/pkg/chains/rekor_test.go
+++ b/pkg/chains/rekor_test.go
@@ -16,9 +16,12 @@ package chains
 import (
 	"testing"
 
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestShouldUploadTlog(t *testing.T) {
@@ -82,7 +85,10 @@ func TestShouldUploadTlog(t *testing.T) {
 				},
 			}
 			cfg := config.Config{Transparency: test.cfg}
-			got := shouldUploadTlog(cfg, tr)
+			ctx, _ := rtesting.SetupFakeContext(t)
+			c := fakepipelineclient.Get(ctx)
+			trObj := objects.NewTaskRunObject(tr, c, ctx)
+			got := shouldUploadTlog(cfg, trObj)
 			if got != test.expected {
 				t.Fatalf("got (%v) doesn't match expected (%v)", got, test.expected)
 			}

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -26,6 +26,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/provenance"
 	"github.com/tektoncd/chains/pkg/chains/formats/simple"
 	"github.com/tektoncd/chains/pkg/chains/formats/tekton"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/chains/signing"
 	"github.com/tektoncd/chains/pkg/chains/signing/kms"
 	"github.com/tektoncd/chains/pkg/chains/signing/x509"
@@ -40,9 +41,7 @@ import (
 
 // TODO: Unclear why an interface is defined here.
 type Signer interface {
-	SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) error
-	// TODO: This is far from ideal. Introduce a more generic "Sign" method?
-	SignPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) error
+	Sign(ctx context.Context, obj interface{}) error
 }
 
 type TaskRunSigner struct {
@@ -116,7 +115,8 @@ func allFormatters(cfg config.Config, l *zap.SugaredLogger) map[formats.PayloadT
 }
 
 // SignTaskRun signs a TaskRun, and marks it as signed.
-func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) error {
+func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
+	tr := object.(*v1beta1.TaskRun)
 	// Get all the things we might need (storage backends, signers and formatters)
 	cfg := *config.FromContext(ctx)
 	logger := logging.FromContext(ctx)
@@ -128,7 +128,8 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 	}
 
 	// Storage
-	allBackends, err := getBackends(ctx, ts.Pipelineclientset, ts.KubeClient, logger, tr, cfg)
+	trObj := objects.NewTaskRunObject(tr, ts.Pipelineclientset, ctx)
+	allBackends, err := getBackends(ctx, ts.Pipelineclientset, ts.KubeClient, logger, trObj, cfg)
 	if err != nil {
 		return err
 	}
@@ -215,7 +216,7 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 				}
 			}
 
-			if shouldUploadTlog(cfg, tr) {
+			if shouldUploadTlog(cfg, trObj) {
 				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
 				if err != nil {
 					logger.Error(err)
@@ -228,7 +229,7 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 			}
 		}
 		if merr.ErrorOrNil() != nil {
-			if err := HandleRetry(ctx, tr, ts.Pipelineclientset, extraAnnotations); err != nil {
+			if err := HandleRetry(ctx, trObj, ts.Pipelineclientset, extraAnnotations); err != nil {
 				merr = multierror.Append(merr, err)
 			}
 			return merr
@@ -236,12 +237,7 @@ func (ts *TaskRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) e
 	}
 
 	// Now mark the TaskRun as signed
-	return MarkSigned(ctx, tr, ts.Pipelineclientset, extraAnnotations)
-}
-
-// SignPipelineRun panics when used.
-func (ts *TaskRunSigner) SignPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) error {
-	panic("TaskRunSigner does not implement SignPipelineRun!")
+	return MarkSigned(ctx, trObj, ts.Pipelineclientset, extraAnnotations)
 }
 
 type PipelineRunSigner struct {
@@ -251,7 +247,9 @@ type PipelineRunSigner struct {
 }
 
 // SignPipelineRun signs a PipelineRun, and marks it as signed.
-func (ps *PipelineRunSigner) SignPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) error {
+// TODO: Alot of overlap with TaskRunSigner.Sign, could probably merge them and pass a generic objects.K8sObject
+func (ps *PipelineRunSigner) Sign(ctx context.Context, object interface{}) error {
+	pr := object.(*v1beta1.PipelineRun)
 	// Get all the things we might need (storage backends, signers and formatters)
 	cfg := *config.FromContext(ctx)
 	logger := logging.FromContext(ctx)
@@ -261,42 +259,123 @@ func (ps *PipelineRunSigner) SignPipelineRun(ctx context.Context, pr *v1beta1.Pi
 	}
 
 	// Storage
+	prObj := objects.NewPipelineRunObject(pr, ps.Pipelineclientset, ctx)
+	allBackends, err := getBackends(ctx, ps.Pipelineclientset, ps.KubeClient, logger, prObj, cfg)
+	if err != nil {
+		return err
+	}
+
+	signers := allSigners(ctx, ps.SecretPath, cfg, logger)
 	allFormats := allFormatters(cfg, logger)
 
+	rekorClient, err := getRekor(cfg.Transparency.URL, logger)
+	if err != nil {
+		return err
+	}
+
+	// TODO: Find things to sign and sign them, probably just the PipelineRun resource itself?
+	// This is where the bulk of the work will reside. Things to consider:
+	// 	* Should this sign any images that were produced by the pipeline? Or should we let
+	//	  the existing mechanisms do that (based on TaskRuns)?
+	//	* If backend is oci, should the PipelineRun attestation be pushed to every repo where
+	//	  an image was pushed? Would this conflict with attestations pushed by SignTaskRun?
+	//	* Implement retries and all that jazz found in SignTaskRun
+	var merr *multierror.Error
 	extraAnnotations := map[string]string{}
 	for _, signableType := range enabledSignableTypes {
 		if !signableType.Enabled(cfg) {
 			continue
 		}
 		payloadFormat := signableType.PayloadFormat(cfg)
-		// Find the right payload format and format the object
-
-		if _, ok := allFormats[payloadFormat]; !ok {
+		payloader, ok := allFormats[payloadFormat]
+		if !ok {
 			logger.Warnf("Format %s configured for PipelineRun: %v %s was not found", payloadFormat, pr, signableType.Type())
 			continue
 		}
 
-		// TODO: Find things to sign and sign them, probably just the PipelineRun resource itself?
-		// This is where the bulk of the work will reside. Things to consider:
-		// 	* Should this sign any images that were produced by the pipeline? Or should we let
-		//	  the existing mechanisms do that (based on TaskRuns)?
-		//	* If backend is oci, should the PipelineRun attestation be pushed to every repo where
-		//	  an image was pushed? Would this conflict with attestations pushed by SignTaskRun?
-		//	* Implement retries and all that jazz found in SignTaskRun
+		objects := signableType.ExtractObjects(pr)
+
+		for _, obj := range objects {
+			payload, err := payloader.CreatePayload(obj)
+			if err != nil {
+				logger.Infof("Error creating payload")
+				logger.Error(err)
+				continue
+			}
+			logger.Infof("Created payload of type %s for Pipelinerun %s/%s", string(payloadFormat), pr.Namespace, pr.Name)
+
+			// Sign it!
+			signerType := signableType.Signer(cfg)
+			signer, ok := signers[signerType]
+			if !ok {
+				logger.Warnf("No signer %s configured for %s", signerType, signableType.Type())
+				continue
+			}
+
+			if payloader.Wrap() {
+				wrapped, err := signing.Wrap(ctx, signer)
+				if err != nil {
+					return err
+				}
+				logger.Infof("Using wrapped envelope signer for %s", payloader.Type())
+				signer = wrapped
+			}
+
+			logger.Infof("Signing object with %s", signerType)
+			rawPayload, err := json.Marshal(payload)
+			if err != nil {
+				logger.Warnf("Unable to marshal payload: %v", signerType, obj)
+				continue
+			}
+
+			signature, err := signer.SignMessage(bytes.NewReader(rawPayload))
+			if err != nil {
+				logger.Error(err)
+				continue
+			}
+
+			// Now store those!
+			for _, backend := range signableType.StorageBackend(cfg).List() {
+				b := allBackends[backend]
+				storageOpts := config.StorageOpts{
+					Key:           signableType.Key(obj),
+					Cert:          signer.Cert(),
+					Chain:         signer.Chain(),
+					PayloadFormat: payloadFormat,
+				}
+				if err := b.StorePayload(ctx, rawPayload, string(signature), storageOpts); err != nil {
+					logger.Error(err)
+					merr = multierror.Append(merr, err)
+				}
+			}
+
+			if shouldUploadTlog(cfg, prObj) {
+				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
+				if err != nil {
+					logger.Error(err)
+					merr = multierror.Append(merr, err)
+				} else {
+					logger.Infof("Uploaded entry to %s with index %d", cfg.Transparency.URL, *entry.LogIndex)
+
+					extraAnnotations[ChainsTransparencyAnnotation] = fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", cfg.Transparency.URL, *entry.LogIndex)
+				}
+			}
+		}
+		if merr.ErrorOrNil() != nil {
+			if err := HandleRetry(ctx, prObj, ps.Pipelineclientset, extraAnnotations); err != nil {
+				merr = multierror.Append(merr, err)
+			}
+			return merr
+		}
 	}
 
 	// Now mark the PipelineRun as signed
-	return MarkPipelineRunSigned(ctx, pr, ps.Pipelineclientset, extraAnnotations)
+	return MarkSigned(ctx, prObj, ps.Pipelineclientset, extraAnnotations)
 }
 
-// SignTaskRun panics when used.
-func (ts *PipelineRunSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) error {
-	panic("PipelineRunSigner does not implement SignTaskRun!")
-}
-
-func HandleRetry(ctx context.Context, tr *v1beta1.TaskRun, ps versioned.Interface, annotations map[string]string) error {
-	if RetryAvailable(tr) {
-		return AddRetry(ctx, tr, ps, annotations)
+func HandleRetry(ctx context.Context, obj objects.K8sObject, ps versioned.Interface, annotations map[string]string) error {
+	if RetryAvailable(obj) {
+		return AddRetry(ctx, obj, ps, annotations)
 	}
-	return MarkFailed(ctx, tr, ps, annotations)
+	return MarkFailed(ctx, obj, ps, annotations)
 }

--- a/pkg/chains/storage/grafeas/grafeas_test.go
+++ b/pkg/chains/storage/grafeas/grafeas_test.go
@@ -155,7 +155,7 @@ func TestBackend_StorePayload(t *testing.T) {
 				signature: "oci signature",
 				// The Key field must be the same as the first 12 chars of the image digest.
 				// Reason:
-				// Inside chains.SignTaskRun function, we set the key field for both artifacts.
+				// Inside chains.Sign function, we set the key field for both artifacts.
 				// For OCI artifact, it is implemented as the first 12 chars of the image digest.
 				// https://github.com/tektoncd/chains/blob/v0.8.0/pkg/artifacts/signable.go#L200
 				opts: config.StorageOpts{Key: "cfe4f0bf41c8", PayloadFormat: formats.PayloadTypeSimpleSigning},

--- a/pkg/chains/storage/storage_test.go
+++ b/pkg/chains/storage/storage_test.go
@@ -17,8 +17,10 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclientset "github.com/tektoncd/pipeline/pkg/client/clientset/versioned/fake"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	"k8s.io/apimachinery/pkg/util/sets"
 	fakekubeclient "knative.dev/pkg/client/injection/kube/client/fake"
@@ -51,7 +53,11 @@ func TestInitializeBackends(t *testing.T) {
 	tr := &v1beta1.TaskRun{}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := InitializeBackends(ctx, ps, kc, logger, tr, tt.cfg)
+			ctx, _ := rtesting.SetupFakeContext(t)
+
+			c := fakepipelineclientset.NewSimpleClientset()
+			trObj := objects.NewTaskRunObject(tr, c, ctx)
+			got, err := InitializeBackends(ctx, ps, kc, logger, trObj, tt.cfg)
 			if err != nil {
 				t.Errorf("InitializeBackends() error = %v", err)
 				return

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
@@ -64,9 +65,8 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 
 			b := &Backend{
-				pipelienclientset: c,
-				logger:            logtesting.TestLogger(t),
-				tr:                tr,
+				logger: logtesting.TestLogger(t),
+				obj:    objects.NewTaskRunObject(tr, c, ctx),
 			}
 			payload, err := json.Marshal(tt.payload)
 			if err != nil {

--- a/pkg/chains/verifier.go
+++ b/pkg/chains/verifier.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/tektoncd/chains/pkg/artifacts"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
@@ -48,7 +49,8 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 	}
 
 	// Storage
-	allBackends, err := getBackends(ctx, tv.Pipelineclientset, tv.KubeClient, logger, tr, cfg)
+	obj := objects.NewTaskRunObject(tr, tv.Pipelineclientset, ctx)
+	allBackends, err := getBackends(ctx, tv.Pipelineclientset, tv.KubeClient, logger, obj, cfg)
 	if err != nil {
 		return err
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -58,7 +58,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) 
 		return nil
 	}
 
-	if err := r.PipelineRunSigner.SignPipelineRun(ctx, pr); err != nil {
+	if err := r.PipelineRunSigner.Sign(ctx, pr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -58,7 +58,7 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1beta1.TaskRun) pkgr
 		return nil
 	}
 
-	if err := r.TaskRunSigner.SignTaskRun(ctx, tr); err != nil {
+	if err := r.TaskRunSigner.Sign(ctx, tr); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -170,12 +170,8 @@ type mockSigner struct {
 	pipelineRunSigned bool
 }
 
-func (m *mockSigner) SignTaskRun(ctx context.Context, tr *v1beta1.TaskRun) error {
+func (m *mockSigner) Sign(ctx context.Context, obj interface{}) error {
 	m.taskRunSigned = true
-	return nil
-}
-
-func (m *mockSigner) SignPipelineRun(ctx context.Context, pr *v1beta1.PipelineRun) error {
 	m.pipelineRunSigned = true
 	return nil
 }


### PR DESCRIPTION
Feature allowing chains to sign `Pipelineruns`. The approach was to abstract away all methods that perform work from referencing `TaskRuns` directly to working on a generic Kubernetes object interface. The interface and structs are defined at `/pkg/chains/objects/objects.go`.

Currently only supports `tekton` storage and the `tekton` format for signing `Pipelineruns`. Therefore the following configuration must be used:
```
artifacts.pipelinerun.storage: tekton
artifacts.pipelinerun.format: tekton
artifacts.oci.storage: ""
transparency.enabled: "true"
```

## How to run
At a high level:
1. Have a chains deployment running and be authenticated to the cluster
2. Edit the chains configuration with the parameters above
3. Clone this repository and checkout the `pipelinerun` branch
4. [Follow @lcarva 's guide on deploying a development version of chains](https://docs.engineering.redhat.com/x/av3rDw)
5. Run a pipeline, wait for chains to sign the pipelinerun, and check the annotations for the payload and signature
