### PR TITLE
Adding oci storage backend for pipelinerun attestations

### DIFF
--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -21,8 +21,12 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
+	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 const (
@@ -33,15 +37,20 @@ const (
 var ignore = []cmp.Option{cmpopts.IgnoreUnexported(name.Registry{}, name.Repository{}, name.Digest{})}
 
 func TestOCIArtifact_ExtractObjects(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	c := fakepipelineclient.Get(ctx)
 
 	tests := []struct {
 		name string
-		tr   *v1beta1.TaskRun
+		obj  objects.K8sObject
 		want []interface{}
 	}{
 		{
 			name: "one image",
-			tr: &v1beta1.TaskRun{
+			obj: objects.NewTaskRunObject(&v1beta1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "TaskRun",
+				},
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						ResourcesResult: []v1beta1.PipelineResourceResult{
@@ -70,12 +79,15 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			},
+			}, c, ctx),
 			want: []interface{}{digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		},
 		{
 			name: "two images",
-			tr: &v1beta1.TaskRun{
+			obj: objects.NewTaskRunObject(&v1beta1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "TaskRun",
+				},
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						ResourcesResult: []v1beta1.PipelineResourceResult{
@@ -120,7 +132,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			},
+			}, c, ctx),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
 				digest(t, "gcr.io/foo/baz@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
@@ -128,7 +140,10 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 		},
 		{
 			name: "resource and result",
-			tr: &v1beta1.TaskRun{
+			obj: objects.NewTaskRunObject(&v1beta1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "TaskRun",
+				},
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						ResourcesResult: []v1beta1.PipelineResourceResult{
@@ -175,14 +190,17 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			},
+			}, c, ctx),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bat@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b4"),
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		},
 		{
 			name: "extra",
-			tr: &v1beta1.TaskRun{
+			obj: objects.NewTaskRunObject(&v1beta1.TaskRun{
+				TypeMeta: metav1.TypeMeta{
+					Kind: "TaskRun",
+				},
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						TaskRunResults: []v1beta1.TaskRunResult{
@@ -231,11 +249,11 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			},
+			}, c, ctx),
 			want: []interface{}{digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		}, {
 			name: "images",
-			tr: &v1beta1.TaskRun{
+			obj: objects.NewTaskRunObject(&v1beta1.TaskRun{
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						TaskRunResults: []v1beta1.TaskRunResult{
@@ -246,14 +264,14 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			},
+			}, c, ctx),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
 				digest(t, "gcr.io/baz/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
 			},
 		}, {
 			name: "images-newline",
-			tr: &v1beta1.TaskRun{
+			obj: objects.NewTaskRunObject(&v1beta1.TaskRun{
 				Status: v1beta1.TaskRunStatus{
 					TaskRunStatusFields: v1beta1.TaskRunStatusFields{
 						TaskRunResults: []v1beta1.TaskRunResult{
@@ -264,7 +282,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			},
+			}, c, ctx),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
 				digest(t, "gcr.io/baz/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
@@ -277,7 +295,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 			oa := &OCIArtifact{
 				Logger: logger,
 			}
-			got := oa.ExtractObjects(tt.tr)
+			got := oa.ExtractObjects(tt.obj)
 			sort.Slice(got, func(i, j int) bool {
 				a := got[i].(name.Digest)
 				b := got[j].(name.Digest)
@@ -291,6 +309,8 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 }
 
 func TestExtractOCIImagesFromResults(t *testing.T) {
+	ctx, _ := rtesting.SetupFakeContext(t)
+	c := fakepipelineclient.Get(ctx)
 	tr := &v1beta1.TaskRun{
 		Status: v1beta1.TaskRunStatus{
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
@@ -305,12 +325,13 @@ func TestExtractOCIImagesFromResults(t *testing.T) {
 			},
 		},
 	}
+	obj := objects.NewTaskRunObject(tr, c, ctx)
 	want := []interface{}{
 		digest(t, fmt.Sprintf("img1@%s", digest1)),
 		digest(t, fmt.Sprintf("img2@%s", digest2)),
 		digest(t, fmt.Sprintf("img3@%s", digest1)),
 	}
-	got := ExtractOCIImagesFromResults(tr, logtesting.TestLogger(t))
+	got := ExtractOCIImagesFromResults(obj, logtesting.TestLogger(t))
 	sort.Slice(got, func(i, j int) bool {
 		a := got[i].(name.Digest)
 		b := got[j].(name.Digest)

--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -27,6 +27,7 @@ import (
 	intoto "github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
@@ -61,20 +62,59 @@ func (i *InTotoIte6) Wrap() bool {
 }
 
 func (i *InTotoIte6) CreatePayload(obj interface{}) (interface{}, error) {
-	var tr *v1beta1.TaskRun
 	switch v := obj.(type) {
 	case *v1beta1.TaskRun:
-		tr = v
+		return i.generateAttestationFromTaskRun(v)
+	case *v1beta1.PipelineRun:
+		return i.generateAttestationFromPipelinerun(v)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)
 	}
-	return i.generateAttestationFromTaskRun(tr)
+}
+
+// There most likely exists a better place to put this, adding as another method for now
+// Possibly a generic attestation interface?
+func (i *InTotoIte6) generateAttestationFromPipelinerun(pr *v1beta1.PipelineRun) (interface{}, error) {
+	// We don't need to pass in a client/context here, as we only want access to the original object
+	// Need a better way to differentiate between an abstracted original k8s object and getting the latest values
+	// - Possibly pass client and context in each method call instead of adding it to the struct?
+	pro := objects.NewPipelineRunObject(pr, nil, nil)
+
+	subjects := GetSubjectDigests(pro, i.logger)
+
+	// Adding a sample value to know the attestation is an example
+	invocation := slsa.ProvenanceInvocation{}
+	params := make(map[string]string)
+	params["message"] = "This is an example attestation for pipelineruns, we'll fill in the details later"
+	invocation.Parameters = params
+
+	att := intoto.ProvenanceStatement{
+		StatementHeader: intoto.StatementHeader{
+			Type:          intoto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject:       subjects,
+		},
+		Predicate: slsa.ProvenancePredicate{
+			Builder: slsa.ProvenanceBuilder{
+				ID: i.builderID,
+			},
+			BuildType:  tektonID,
+			Invocation: invocation,
+			// BuildConfig: buildConfig(tr),
+			// Metadata:    metadata(tr),
+			// Materials:   materials(tr),
+		},
+	}
+	return att, nil
 }
 
 // generateAttestationFromTaskRun translates a Tekton TaskRun into an in-toto attestation
 // with the slsa-provenance predicate type
 func (i *InTotoIte6) generateAttestationFromTaskRun(tr *v1beta1.TaskRun) (interface{}, error) {
-	subjects := GetSubjectDigests(tr, i.logger)
+	// We only want access to the original object, no need to pass in a client/context
+	tro := objects.NewTaskRunObject(tr, nil, nil)
+
+	subjects := GetSubjectDigests(tro, i.logger)
 
 	att := intoto.ProvenanceStatement{
 		StatementHeader: intoto.StatementHeader{
@@ -140,10 +180,9 @@ func invocation(tr *v1beta1.TaskRun) slsa.ProvenanceInvocation {
 
 // GetSubjectDigests extracts OCI images from the TaskRun based on standard hinting set up
 // It also goes through looking for any PipelineResources of Image type
-func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []intoto.Subject {
+func GetSubjectDigests(obj objects.K8sObject, logger *zap.SugaredLogger) []intoto.Subject {
 	var subjects []intoto.Subject
-
-	imgs := artifacts.ExtractOCIImagesFromResults(tr, logger)
+	imgs := artifacts.ExtractOCIImagesFromResults(obj, logger)
 	for _, i := range imgs {
 		if d, ok := i.(name.Digest); ok {
 			subjects = append(subjects, intoto.Subject{
@@ -155,7 +194,13 @@ func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []intoto.
 		}
 	}
 
-	if tr.Spec.Resources == nil {
+	// Check if object is a Taskrun, if so search for images used in PipelineResources
+	// Otherwise object is a PipelineRun, where Pipelineresources are not relevant.
+	// PipelineResources have been deprecated so their support has been left out of
+	// the POC for TEP-84
+	// More info: https://tekton.dev/docs/pipelines/resources/
+	tr, ok := obj.GetObject().(*v1beta1.TaskRun)
+	if !ok || tr.Spec.Resources == nil {
 		return subjects
 	}
 

--- a/pkg/chains/formats/intotoite6/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/provenance_test.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/in-toto/in-toto-golang/in_toto"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"github.com/tektoncd/pipeline/pkg/apis/resource/v1alpha1"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -278,7 +279,8 @@ func TestGetSubjectDigests(t *testing.T) {
 			},
 		},
 	}
-	got := GetSubjectDigests(tr, logtesting.TestLogger(t))
+	tro := objects.NewTaskRunObject(tr, nil, nil)
+	got := GetSubjectDigests(tro, logtesting.TestLogger(t))
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/chains/formats/provenance/provenance.go
+++ b/pkg/chains/formats/provenance/provenance.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/chains/provenance"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
@@ -327,8 +328,8 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 // calculating a hash of a previous step.
 func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []in_toto.Subject {
 	var subjects []in_toto.Subject
-
-	imgs := artifacts.ExtractOCIImagesFromResults(tr, logger)
+	tro := objects.NewTaskRunObject(tr, nil, nil)
+	imgs := artifacts.ExtractOCIImagesFromResults(tro, logger)
 	for _, i := range imgs {
 		if d, ok := i.(name.Digest); ok {
 			subjects = append(subjects, in_toto.Subject{

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -159,7 +159,7 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 
 		// Extract all the "things" to be signed.
 		// We might have a few of each type (several binaries, or images)
-		objects := signableType.ExtractObjects(tr)
+		objects := signableType.ExtractObjects(trObj)
 
 		// Go through each object one at a time.
 		for _, obj := range objects {
@@ -293,7 +293,7 @@ func (ps *PipelineRunSigner) Sign(ctx context.Context, object interface{}) error
 			continue
 		}
 
-		objects := signableType.ExtractObjects(pr)
+		objects := signableType.ExtractObjects(prObj)
 
 		for _, obj := range objects {
 			payload, err := payloader.CreatePayload(obj)

--- a/pkg/chains/storage/grafeas/grafeas.go
+++ b/pkg/chains/storage/grafeas/grafeas.go
@@ -26,6 +26,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/tektoncd/chains/pkg/artifacts"
 	"github.com/tektoncd/chains/pkg/chains/formats"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
@@ -368,7 +369,8 @@ func (b *Backend) getOCIURI(opts config.StorageOpts) string {
 // get the uri of all images for a specific taskrun in the format of `IMAGE_URL@IMAGE_DIGEST`
 func (b *Backend) retrieveAllOCIURIs() []string {
 	result := []string{}
-	images := artifacts.ExtractOCIImagesFromResults(b.tr, b.logger)
+	trObj := objects.NewTaskRunObject(b.tr, nil, nil)
+	images := artifacts.ExtractOCIImagesFromResults(trObj, b.logger)
 
 	for _, image := range images {
 		ref := image.(name.Digest)

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/in-toto/in-toto-golang/in_toto"
 	slsa "github.com/in-toto/in-toto-golang/in_toto/slsa_provenance/v0.2"
 	"github.com/sigstore/sigstore/pkg/signature/payload"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	remotetest "github.com/tektoncd/pipeline/test"
 	corev1 "k8s.io/api/core/v1"
@@ -181,9 +182,15 @@ func TestBackend_StorePayload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			// Trying to create context fails with "Unable to fetch labelkey from context."
+			// We don't need the context or client so we'll just pass nil for now
+			// ctx, _ := rtesting.SetupFakeContext(t)
+			// c := fakepipelineclient.Get(ctx)
+			// obj := objects.NewTaskRunObject(tt.fields.tr, c, ctx)
+			obj := objects.NewTaskRunObject(tt.fields.tr, nil, nil)
 			b := &Backend{
 				logger: logtesting.TestLogger(t),
-				tr:     tt.fields.tr,
+				obj:    obj,
 				cfg:    tt.fields.cfg,
 				kc:     tt.fields.kc,
 				auth:   tt.fields.auth,

--- a/pkg/chains/storage/storage.go
+++ b/pkg/chains/storage/storage.go
@@ -72,12 +72,7 @@ func InitializeBackends(ctx context.Context, ps versioned.Interface, kc kubernet
 		case tekton.StorageBackendTekton:
 			backends[backendType] = tekton.NewStorageBackend(logger, obj)
 		case oci.StorageBackendOCI:
-			tr, ok := obj.GetObject().(*v1beta1.TaskRun)
-			if !ok {
-				logger.Error("PipelineRun does not currently support OCI backend")
-				continue
-			}
-			ociBackend, err := oci.NewStorageBackend(ctx, logger, kc, tr, cfg)
+			ociBackend, err := oci.NewStorageBackend(ctx, logger, kc, obj, cfg)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
## Overview

Add's the OCI storage backend to `PipelineRun` attestations. 

Some important notes:

**What are the major changes?**
The changes can be summarized as:
- Since OCI storage only supports the `intoto` format, `pkg/chains/formats/intotoite6/intotoite6.go` was modified to support generating attestations for `PipelineRun`'s. The attestation only has sample values for now.
- The OCI artifact in `pkg/artifacts/signable.go` has been modified to extract the image URL and digest from the results list of `PipelineRun`'s.
- All other changes are implications of the previous two, with a focus on abstracting function calls to use `objects.K8sObject`

**How does chains know which registry to store the attestation in?**
`TaskRuns` discover the registry by looking for the `IMAGE_URL` and `IMAGE_DIGEST` key's in the results list. We can reuse this code by adding the same keys to the `Pipeline` [results list](https://tekton.dev/docs/pipelines/pipelines/#emitting-results-from-a-pipeline):
```
  results:
  - description: Digest of the image just built.
    name: IMAGE_DIGEST
    value: $(tasks.build.results.IMAGE_DIGEST)
  - description: URL of the image just built.
    name: IMAGE_URL
    value: $(tasks.build.results.IMAGE_URL)
```

**What information is in the Pipelinerun attestation?**
As of now only the build ID and a sample message. What information and structure of the attestation is somewhat a complex task so it is out of scope for this PR.

## How to test
At a high level:
- Deploy chains normally through infra-deployments
- Turn of gitops sync
  `infra-deployments/hack/chains/gitops-sync.sh off`
- Edit the configuration to sign `Pipelinerun`'s:
  ```
  artifacts.pipelinerun.storage: oci
  artifacts.pipelinerun.format: in-toto
  artifacts.oci.storage: oci
  transparency.enabled: "true"
  ```
- Modify chains to use this branch (Using @lcarva's guide)
- Apply the following `Pipeline` to the cluster:
  ```
  apiVersion: tekton.dev/v1beta1
  kind: Pipeline
  metadata:
    name: chains-demo-pipeline-attestation
    namespace: tekton-chains
  spec:
    params:
    - description: Image path on registry
      name: IMAGE
      type: string
    - description: Registry secret name for push
      name: PUSH_SECRET_NAME
      type: string
    results:
    - description: Digest of the image just built.
      name: IMAGE_DIGEST
      value: $(tasks.build.results.IMAGE_DIGEST)
    - description: URL of the image just built.
      name: IMAGE_URL
      value: $(tasks.build.results.IMAGE_URL)
    tasks:
    - name: git-clone
      params:
      - name: url
        value: https://github.com/caugello/single-nodejs-app
      - name: deleteExisting
        value: "true"
      - name: verbose
        value: "true"
      taskRef:
        kind: ClusterTask
        name: git-clone
      workspaces:
      - name: output
        workspace: source
    - name: build
      params:
      - name: IMAGE
        value: $(params.IMAGE)
      - name: PUSH_SECRET_NAME
        value: $(params.PUSH_SECRET_NAME)
      - name: TLSVERIFY
        value: "true"
      - name: CHAINS-GIT_COMMIT
        value: $(tasks.git-clone.results.commit)
      - name: CHAINS-GIT_URL
        value: $(tasks.git-clone.results.url)
      runAfter:
      - git-clone
      taskRef:
        kind: ClusterTask
        name: s2i-nodejs-chains
      workspaces:
      - name: source
        workspace: source
    workspaces:
    - name: source
  ```
- Replace `chains-demo-pipeline` with `chains-demo-pipeline-attestation` in `infra-deployments/hack/chains/pipeline-quay-demo.sh`
- Run the `infra-deployments/hack/chains/pipeline-quay-demo.sh` script
`./pipeline-quay-demo.sh  quay.io/your-user/your-repo your-quay-secret-name`
