### PR TITLE
Refactoring generic k8s object abstraction

### DIFF
--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -23,10 +23,8 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	logtesting "knative.dev/pkg/logging/testing"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 const (
@@ -37,8 +35,6 @@ const (
 var ignore = []cmp.Option{cmpopts.IgnoreUnexported(name.Registry{}, name.Repository{}, name.Digest{})}
 
 func TestOCIArtifact_ExtractObjects(t *testing.T) {
-	ctx, _ := rtesting.SetupFakeContext(t)
-	c := fakepipelineclient.Get(ctx)
 
 	tests := []struct {
 		name string
@@ -79,7 +75,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			}, c, ctx),
+			}),
 			want: []interface{}{digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		},
 		{
@@ -132,7 +128,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			}, c, ctx),
+			}),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
 				digest(t, "gcr.io/foo/baz@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
@@ -190,7 +186,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			}, c, ctx),
+			}),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bat@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b4"),
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
@@ -249,7 +245,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			}, c, ctx),
+			}),
 			want: []interface{}{digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5")},
 		}, {
 			name: "images",
@@ -264,7 +260,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			}, c, ctx),
+			}),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
 				digest(t, "gcr.io/baz/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
@@ -282,7 +278,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 						},
 					},
 				},
-			}, c, ctx),
+			}),
 			want: []interface{}{
 				digest(t, "gcr.io/foo/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b5"),
 				digest(t, "gcr.io/baz/bar@sha256:05f95b26ed10668b7183c1e2da98610e91372fa9f510046d4ce5812addad86b6"),
@@ -309,8 +305,6 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 }
 
 func TestExtractOCIImagesFromResults(t *testing.T) {
-	ctx, _ := rtesting.SetupFakeContext(t)
-	c := fakepipelineclient.Get(ctx)
 	tr := &v1beta1.TaskRun{
 		Status: v1beta1.TaskRunStatus{
 			TaskRunStatusFields: v1beta1.TaskRunStatusFields{
@@ -325,7 +319,7 @@ func TestExtractOCIImagesFromResults(t *testing.T) {
 			},
 		},
 	}
-	obj := objects.NewTaskRunObject(tr, c, ctx)
+	obj := objects.NewTaskRunObject(tr)
 	want := []interface{}{
 		digest(t, fmt.Sprintf("img1@%s", digest1)),
 		digest(t, fmt.Sprintf("img2@%s", digest2)),

--- a/pkg/chains/annotations.go
+++ b/pkg/chains/annotations.go
@@ -102,7 +102,7 @@ func AddAnnotation(ctx context.Context, obj objects.K8sObject, ps versioned.Inte
 	if err != nil {
 		return err
 	}
-	err = obj.Patch(patchBytes)
+	err = obj.Patch(ctx, ps, patchBytes)
 	if err != nil {
 		return err
 	}

--- a/pkg/chains/annotations_test.go
+++ b/pkg/chains/annotations_test.go
@@ -97,14 +97,12 @@ func TestRetryAvailble(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			ctx, _ := rtesting.SetupFakeContext(t)
-			c := fakepipelineclient.Get(ctx)
 			tr := &v1beta1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: test.annotations,
 				},
 			}
-			trObj := objects.NewTaskRunObject(tr, c, ctx)
+			trObj := objects.NewTaskRunObject(tr)
 			got := RetryAvailable(trObj)
 			if got != test.expected {
 				t.Fatalf("RetryAvailble() got %v expected %v", got, test.expected)
@@ -124,7 +122,7 @@ func TestAddRetry(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	trObj := objects.NewTaskRunObject(tr, c, ctx)
+	trObj := objects.NewTaskRunObject(tr)
 
 	// run it through AddRetry, make sure annotation is added
 	if err := AddRetry(ctx, trObj, c, nil); err != nil {
@@ -141,7 +139,7 @@ func TestAddRetry(t *testing.T) {
 	}
 
 	// run it again, make sure we see an increase
-	trObj = objects.NewTaskRunObject(signed, c, ctx)
+	trObj = objects.NewTaskRunObject(signed)
 	if err := AddRetry(ctx, trObj, c, nil); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/chains/formats/intotoite6/taskrun/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/taskrun/provenance_test.go
@@ -280,7 +280,7 @@ func TestGetSubjectDigests(t *testing.T) {
 			},
 		},
 	}
-	tro := objects.NewTaskRunObject(tr, nil, nil)
+	tro := objects.NewTaskRunObject(tr)
 	got := util.GetSubjectDigests(tro, logtesting.TestLogger(t))
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {

--- a/pkg/chains/formats/intotoite6/taskrun/taskrun.go
+++ b/pkg/chains/formats/intotoite6/taskrun/taskrun.go
@@ -13,8 +13,7 @@ import (
 )
 
 func GenerateAttestation(builderID string, tr *v1beta1.TaskRun, logger *zap.SugaredLogger) (interface{}, error) {
-	// We only want access to the original object, no need to pass in a client/context
-	tro := objects.NewTaskRunObject(tr, nil, nil)
+	tro := objects.NewTaskRunObject(tr)
 	subjects := util.GetSubjectDigests(tro, logger)
 
 	att := intoto.ProvenanceStatement{

--- a/pkg/chains/formats/provenance/provenance.go
+++ b/pkg/chains/formats/provenance/provenance.go
@@ -328,7 +328,7 @@ func gitInfo(tr *v1beta1.TaskRun) (commit string, url string) {
 // calculating a hash of a previous step.
 func GetSubjectDigests(tr *v1beta1.TaskRun, logger *zap.SugaredLogger) []in_toto.Subject {
 	var subjects []in_toto.Subject
-	tro := objects.NewTaskRunObject(tr, nil, nil)
+	tro := objects.NewTaskRunObject(tr)
 	imgs := artifacts.ExtractOCIImagesFromResults(tro, logger)
 	for _, i := range imgs {
 		if d, ok := i.(name.Digest); ok {

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -34,24 +34,20 @@ type K8sObject interface {
 	GetNamespace() string
 	GetKind() string
 	GetAnnotation(annotation string) *Annotation
-	GetLatestAnnotation(annotation string) *Annotation
+	GetLatestAnnotation(ctx context.Context, clientSet versioned.Interface, annotation string) *Annotation
 	GetObject() interface{}
-	Patch(patchBytes []byte) error
+	Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error
 	GetResults() []Result          // TODO: Abstract this further to return any field in the status
 	GetServiceAccountName() string // TODO: Abstract this further to return any field in the spec
 }
 
 type TaskRunObject struct {
-	tr        *v1beta1.TaskRun
-	clientSet versioned.Interface
-	ctx       context.Context
+	tr *v1beta1.TaskRun
 }
 
-func NewTaskRunObject(tr *v1beta1.TaskRun, clientSet versioned.Interface, ctx context.Context) *TaskRunObject {
+func NewTaskRunObject(tr *v1beta1.TaskRun) *TaskRunObject {
 	return &TaskRunObject{
-		tr:        tr,
-		clientSet: clientSet,
-		ctx:       ctx,
+		tr: tr,
 	}
 }
 
@@ -76,8 +72,8 @@ func (tro *TaskRunObject) GetAnnotation(annotation string) *Annotation {
 	}
 }
 
-func (tro *TaskRunObject) GetLatestAnnotation(annotation string) *Annotation {
-	tr, err := tro.clientSet.TektonV1beta1().TaskRuns(tro.tr.Namespace).Get(tro.ctx, tro.tr.Name, v1.GetOptions{})
+func (tro *TaskRunObject) GetLatestAnnotation(ctx context.Context, clientSet versioned.Interface, annotation string) *Annotation {
+	tr, err := clientSet.TektonV1beta1().TaskRuns(tro.tr.Namespace).Get(ctx, tro.tr.Name, v1.GetOptions{})
 	if err != nil {
 		return &Annotation{
 			Err:   fmt.Errorf("error retrieving taskrun: %s", err),
@@ -97,9 +93,9 @@ func (tro *TaskRunObject) GetObject() interface{} {
 	return tro.tr
 }
 
-func (tro *TaskRunObject) Patch(patchBytes []byte) error {
-	_, err := tro.clientSet.TektonV1beta1().TaskRuns(tro.tr.Namespace).Patch(
-		tro.ctx, tro.tr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
+func (tro *TaskRunObject) Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error {
+	_, err := clientSet.TektonV1beta1().TaskRuns(tro.tr.Namespace).Patch(
+		ctx, tro.tr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
 	return err
 }
 
@@ -153,8 +149,8 @@ func (pro *PipelineRunObject) GetAnnotation(annotation string) *Annotation {
 	}
 }
 
-func (pro *PipelineRunObject) GetLatestAnnotation(annotation string) *Annotation {
-	tr, err := pro.clientSet.TektonV1beta1().PipelineRuns(pro.pr.Namespace).Get(pro.ctx, pro.pr.Name, v1.GetOptions{})
+func (pro *PipelineRunObject) GetLatestAnnotation(ctx context.Context, clientSet versioned.Interface, annotation string) *Annotation {
+	tr, err := clientSet.TektonV1beta1().PipelineRuns(pro.pr.Namespace).Get(ctx, pro.pr.Name, v1.GetOptions{})
 	if err != nil {
 		return &Annotation{
 			Err:   fmt.Errorf("error retrieving pipelinerun: %s", err),
@@ -174,9 +170,9 @@ func (pro *PipelineRunObject) GetObject() interface{} {
 	return pro.pr
 }
 
-func (pro *PipelineRunObject) Patch(patchBytes []byte) error {
-	_, err := pro.clientSet.TektonV1beta1().PipelineRuns(pro.pr.Namespace).Patch(
-		pro.ctx, pro.pr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
+func (pro *PipelineRunObject) Patch(ctx context.Context, clientSet versioned.Interface, patchBytes []byte) error {
+	_, err := clientSet.TektonV1beta1().PipelineRuns(pro.pr.Namespace).Patch(
+		ctx, pro.pr.Name, types.MergePatchType, patchBytes, v1.PatchOptions{})
 	return err
 }
 

--- a/pkg/chains/rekor_test.go
+++ b/pkg/chains/rekor_test.go
@@ -19,9 +19,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
-	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	rtesting "knative.dev/pkg/reconciler/testing"
 )
 
 func TestShouldUploadTlog(t *testing.T) {
@@ -85,9 +83,7 @@ func TestShouldUploadTlog(t *testing.T) {
 				},
 			}
 			cfg := config.Config{Transparency: test.cfg}
-			ctx, _ := rtesting.SetupFakeContext(t)
-			c := fakepipelineclient.Get(ctx)
-			trObj := objects.NewTaskRunObject(tr, c, ctx)
+			trObj := objects.NewTaskRunObject(tr)
 			got := shouldUploadTlog(cfg, trObj)
 			if got != test.expected {
 				t.Fatalf("got (%v) doesn't match expected (%v)", got, test.expected)

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -130,7 +130,7 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 	}
 
 	tr := object.(*v1beta1.TaskRun)
-	trObj := objects.NewTaskRunObject(tr, ts.Pipelineclientset, ctx)
+	trObj := objects.NewTaskRunObject(tr)
 
 	signers := allSigners(ctx, ts.SecretPath, cfg, logger)
 
@@ -207,7 +207,7 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 					Chain:         signer.Chain(),
 					PayloadFormat: payloadFormat,
 				}
-				if err := b.StorePayload(ctx, trObj, rawPayload, string(signature), storageOpts); err != nil {
+				if err := b.StorePayload(ctx, ts.Pipelineclientset, trObj, rawPayload, string(signature), storageOpts); err != nil {
 					logger.Error(err)
 					merr = multierror.Append(merr, err)
 				}
@@ -341,7 +341,7 @@ func (ps *PipelineRunSigner) Sign(ctx context.Context, object interface{}) error
 					Chain:         signer.Chain(),
 					PayloadFormat: payloadFormat,
 				}
-				if err := b.StorePayload(ctx, prObj, rawPayload, string(signature), storageOpts); err != nil {
+				if err := b.StorePayload(ctx, ps.Pipelineclientset, prObj, rawPayload, string(signature), storageOpts); err != nil {
 					logger.Error(err)
 					merr = multierror.Append(merr, err)
 				}

--- a/pkg/chains/signing_test.go
+++ b/pkg/chains/signing_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/storage"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	versioned "github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	fakepipelineclient "github.com/tektoncd/pipeline/pkg/client/injection/client/fake"
 	"go.uber.org/zap"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -47,7 +48,7 @@ func TestMarkSigned(t *testing.T) {
 			},
 		},
 	}
-	trObj := objects.NewTaskRunObject(tr, c, ctx)
+	trObj := objects.NewTaskRunObject(tr)
 	if _, err := c.TektonV1beta1().TaskRuns(tr.Namespace).Create(ctx, tr, metav1.CreateOptions{}); err != nil {
 		t.Fatal(err)
 	}
@@ -110,7 +111,7 @@ func TestMarkFailed(t *testing.T) {
 	}
 
 	// Test HandleRetry, should mark it as failed
-	trObj := objects.NewTaskRunObject(tr, c, ctx)
+	trObj := objects.NewTaskRunObject(tr)
 	if err := HandleRetry(ctx, trObj, c, nil); err != nil {
 		t.Errorf("HandleRetry() error = %v", err)
 	}
@@ -366,7 +367,7 @@ type mockBackend struct {
 }
 
 // StorePayload implements the Payloader interface.
-func (b *mockBackend) StorePayload(ctx context.Context, _ objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *mockBackend) StorePayload(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	if b.shouldErr {
 		return errors.New("mock error storing")
 	}
@@ -378,10 +379,10 @@ func (b *mockBackend) Type() string {
 	return b.backendType
 }
 
-func (b *mockBackend) RetrievePayloads(ctx context.Context, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *mockBackend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
 	return nil, fmt.Errorf("not implemented")
 }
 
-func (b *mockBackend) RetrieveSignatures(ctx context.Context, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *mockBackend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
 	return nil, fmt.Errorf("not implemented")
 }

--- a/pkg/chains/storage/docdb/docdb.go
+++ b/pkg/chains/storage/docdb/docdb.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 	"gocloud.dev/docstore"
 	_ "gocloud.dev/docstore/awsdynamodb"
@@ -61,7 +62,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 }
 
 // StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(ctx context.Context, _ objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	var obj interface{}
 	if err := json.Unmarshal(rawPayload, &obj); err != nil {
 		return err
@@ -87,7 +88,7 @@ func (b *Backend) Type() string {
 	return StorageTypeDocDB
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
 	// Retrieve the document.
 	documents, err := b.retrieveDocuments(ctx, opts)
 	if err != nil {
@@ -106,7 +107,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, _ objects.K8sObject, o
 	return m, nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
 	documents, err := b.retrieveDocuments(ctx, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/chains/storage/gcs/gcs.go
+++ b/pkg/chains/storage/gcs/gcs.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 )
 
@@ -61,7 +62,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 }
 
 // StorePayload implements the storage.Backend interface.
-func (b *Backend) StorePayload(ctx context.Context, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// We need multiple objects: the signature and the payload. We want to make these unique to the UID, but easy to find based on the
@@ -144,7 +145,7 @@ func (r *reader) GetReader(ctx context.Context, object string) (io.ReadCloser, e
 	return r.client.Bucket(r.bucket).Object(object).NewReader(ctx)
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	object := sigName(tr, opts)
@@ -158,7 +159,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, obj objects.K8sObject,
 	return m, nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	object := payloadName(tr, opts)

--- a/pkg/chains/storage/grafeas/grafeas.go
+++ b/pkg/chains/storage/grafeas/grafeas.go
@@ -29,6 +29,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -84,7 +85,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 }
 
 // StorePayload implements the storage.Backend interface.
-func (b *Backend) StorePayload(ctx context.Context, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// TODO: Gracefully handle unexpected type
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// We only support simplesigning for OCI images, and in-toto for taskrun.
@@ -127,7 +128,7 @@ func (b *Backend) StorePayload(ctx context.Context, obj objects.K8sObject, rawPa
 }
 
 // Retrieve payloads from grafeas server and store it in a map
-func (b *Backend) RetrievePayloads(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
 	// TODO: Gracefully handle unexpected type
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// initialize an empty map for result
@@ -152,7 +153,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, obj objects.K8sObject, o
 }
 
 // Retrieve signatures from grafeas server and store it in a map
-func (b *Backend) RetrieveSignatures(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
 	// TODO: Gracefully handle unexpected type
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// initialize an empty map for result
@@ -373,7 +374,7 @@ func (b *Backend) getOCIURI(tr *v1beta1.TaskRun, opts config.StorageOpts) string
 // get the uri of all images for a specific taskrun in the format of `IMAGE_URL@IMAGE_DIGEST`
 func (b *Backend) retrieveAllOCIURIs(tr *v1beta1.TaskRun) []string {
 	result := []string{}
-	trObj := objects.NewTaskRunObject(tr, nil, nil)
+	trObj := objects.NewTaskRunObject(tr)
 	images := artifacts.ExtractOCIImagesFromResults(trObj, b.logger)
 
 	for _, image := range images {

--- a/pkg/chains/storage/oci/oci.go
+++ b/pkg/chains/storage/oci/oci.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/objects"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 
 	"github.com/in-toto/in-toto-golang/in_toto"
 	"github.com/secure-systems-lab/go-securesystemslib/dsse"
@@ -70,7 +71,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, client ku
 }
 
 // StorePayload implements the storage.Backend interface.
-func (b *Backend) StorePayload(ctx context.Context, obj objects.K8sObject, rawPayload []byte, signature string, storageOpts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, storageOpts config.StorageOpts) error {
 	// TODO: Handle unexpected type gracefully
 	auth, err := b.getAuthenticator(ctx, obj, b.client)
 	if err != nil {
@@ -206,7 +207,7 @@ func (b *Backend) Type() string {
 	return StorageBackendOCI
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
 	images, err := b.RetrieveArtifact(ctx, obj, opts)
 	if err != nil {
 		return nil, err
@@ -234,7 +235,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, obj objects.K8sObject,
 	return m, nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
 	var err error
 	images, err := b.RetrieveArtifact(ctx, obj, opts)
 	if err != nil {

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -158,12 +158,7 @@ func TestBackend_StorePayload(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Trying to create context fails with "Unable to fetch labelkey from context."
-			// We don't need the context or client so we'll just pass nil for now
-			// ctx, _ := rtesting.SetupFakeContext(t)
-			// c := fakepipelineclient.Get(ctx)
-			// obj := objects.NewTaskRunObject(tt.fields.tr, c, ctx)
-			trObj := objects.NewTaskRunObject(tt.fields.tr, nil, nil)
+			trObj := objects.NewTaskRunObject(tt.fields.tr)
 			b := &Backend{
 				logger: logtesting.TestLogger(t),
 				getAuthenticator: func(_ context.Context, _ objects.K8sObject, _ kubernetes.Interface) (remote.Option, error) {
@@ -174,7 +169,11 @@ func TestBackend_StorePayload(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to marshal: %v", err)
 			}
-			if err := b.StorePayload(ctx, trObj, rawPayload, tt.args.signature, tt.args.storageOpts); (err != nil) != tt.wantErr {
+			// TODO: Passing in fake client with the following fails with "Unable to fetch labelkey from context.",
+			// need to diagnose why. Client isn't used so we can get away with passing nil for now.
+			// 	ctx, _ := rtesting.SetupFakeContext(t)
+			// c := fakepipelineclient.Get(ctx)
+			if err := b.StorePayload(ctx, nil, trObj, rawPayload, tt.args.signature, tt.args.storageOpts); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/chains/storage/pubsub/pubsub.go
+++ b/pkg/chains/storage/pubsub/pubsub.go
@@ -21,6 +21,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
 	"go.uber.org/zap"
 	"gocloud.dev/pubsub/kafkapubsub"
 
@@ -53,7 +54,7 @@ func (b *Backend) Type() string {
 	return StorageBackendPubSub
 }
 
-func (b *Backend) StorePayload(ctx context.Context, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	b.logger.Infof("Storing payload on TaskRun %s/%s", tr.Namespace, tr.Name)
@@ -84,11 +85,11 @@ func (b *Backend) StorePayload(ctx context.Context, obj objects.K8sObject, rawPa
 	return nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
 	return nil, fmt.Errorf("not implemented for this storage backend: %s", b.Type())
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
 	return nil, fmt.Errorf("not implemented for this storage backend: %s", b.Type())
 }
 

--- a/pkg/chains/storage/storage.go
+++ b/pkg/chains/storage/storage.go
@@ -31,11 +31,11 @@ import (
 
 // Backend is an interface to store a chains Payload
 type Backend interface {
-	StorePayload(ctx context.Context, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error
+	StorePayload(ctx context.Context, clientSet versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error
 	// RetrievePayloads maps [ref]:[payload] for a TaskRun
-	RetrievePayloads(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error)
+	RetrievePayloads(ctx context.Context, clientSet versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error)
 	// RetrieveSignatures maps [ref]:[list of signatures] for a TaskRun
-	RetrieveSignatures(ctx context.Context, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error)
+	RetrieveSignatures(ctx context.Context, clientSet versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error)
 	// Type is the string representation of the backend
 	Type() string
 }
@@ -68,12 +68,6 @@ func InitializeBackends(ctx context.Context, ps versioned.Interface, kc kubernet
 			backends[backendType] = tekton.NewStorageBackend(ps, logger)
 		case oci.StorageBackendOCI:
 			ociBackend := oci.NewStorageBackend(ctx, logger, kc, cfg)
-			// =======
-			// 			ociBackend, err := oci.NewStorageBackend(ctx, logger, kc, obj, cfg)
-			// 			if err != nil {
-			// 				return nil, err
-			// 			}
-			// >>>>>>> 1eec2732 (Adding OCI storage option to Pipeline attestations)
 			backends[backendType] = ociBackend
 		case docdb.StorageTypeDocDB:
 			docdbBackend, err := docdb.NewStorageBackend(ctx, logger, cfg)

--- a/pkg/chains/storage/tekton/tekton_test.go
+++ b/pkg/chains/storage/tekton/tekton_test.go
@@ -74,8 +74,8 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 			opts := config.StorageOpts{Key: "mockpayload"}
 			mockSignature := "mocksignature"
-			trObj := objects.NewTaskRunObject(tr, c, ctx)
-			if err := b.StorePayload(ctx, trObj, payload, mockSignature, opts); (err != nil) != tt.wantErr {
+			trObj := objects.NewTaskRunObject(tr)
+			if err := b.StorePayload(ctx, c, trObj, payload, mockSignature, opts); (err != nil) != tt.wantErr {
 				t.Errorf("Backend.StorePayload() error = %v, wantErr %v", err, tt.wantErr)
 			}
 
@@ -85,7 +85,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			}
 
 			payloadAnnotation := payloadName(opts)
-			payloads, err := b.RetrievePayloads(ctx, trObj, opts)
+			payloads, err := b.RetrievePayloads(ctx, c, trObj, opts)
 			if err != nil {
 				t.Errorf("error base64 decoding: %v", err)
 			}
@@ -102,7 +102,7 @@ func TestBackend_StorePayload(t *testing.T) {
 
 			// Compare the signature.
 			signatureAnnotation := sigName(opts)
-			sigs, err := b.RetrieveSignatures(ctx, trObj, opts)
+			sigs, err := b.RetrieveSignatures(ctx, c, trObj, opts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/chains/verifier.go
+++ b/pkg/chains/verifier.go
@@ -49,8 +49,7 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 		&artifacts.OCIArtifact{Logger: logger},
 	}
 
-	// TODO: Use non-nil clientset?
-	trObj := objects.NewTaskRunObject(tr, nil, ctx)
+	trObj := objects.NewTaskRunObject(tr)
 
 	// Storage
 	allBackends, err := storage.InitializeBackends(ctx, tv.Pipelineclientset, tv.KubeClient, logger, cfg)
@@ -73,11 +72,11 @@ func (tv *TaskRunVerifier) VerifyTaskRun(ctx context.Context, tr *v1beta1.TaskRu
 
 		for _, backend := range signableType.StorageBackend(cfg).List() {
 			b := allBackends[backend]
-			signatures, err := b.RetrieveSignatures(ctx, trObj, config.StorageOpts{})
+			signatures, err := b.RetrieveSignatures(ctx, tv.Pipelineclientset, trObj, config.StorageOpts{})
 			if err != nil {
 				return err
 			}
-			payload, err := b.RetrievePayloads(ctx, trObj, config.StorageOpts{})
+			payload, err := b.RetrievePayloads(ctx, tv.Pipelineclientset, trObj, config.StorageOpts{})
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Removing the context and k8s client from the state of `k8sObject`. Most methods won't use the client and is only required for a specific section of the codebase (`storage`). 

Instead methods that require up to date information will need to be provided the context and client.