### PR TITLE
Refactoring to use generic k8s interface

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -27,7 +27,7 @@ import (
 )
 
 type Signable interface {
-	ExtractObjects(obj objects.K8sObject) []interface{}
+	ExtractObjects(obj objects.TektonObject) []interface{}
 	StorageBackend(cfg config.Config) sets.String
 	Signer(cfg config.Config) string
 	PayloadFormat(cfg config.Config) formats.PayloadType
@@ -45,7 +45,7 @@ func (ta *TaskRunArtifact) Key(obj interface{}) string {
 	return "taskrun-" + string(tr.UID)
 }
 
-func (ta *TaskRunArtifact) ExtractObjects(obj objects.K8sObject) []interface{} {
+func (ta *TaskRunArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	return []interface{}{tr}
 }
@@ -79,7 +79,7 @@ func (pa *PipelineRunArtifact) Key(obj interface{}) string {
 	return "pipelinerun-" + string(pr.UID)
 }
 
-func (pa *PipelineRunArtifact) ExtractObjects(obj objects.K8sObject) []interface{} {
+func (pa *PipelineRunArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
 	pr := obj.GetObject().(*v1beta1.PipelineRun)
 	return []interface{}{pr}
 }
@@ -114,7 +114,7 @@ type image struct {
 	digest string
 }
 
-func (oa *OCIArtifact) ExtractObjects(obj objects.K8sObject) []interface{} {
+func (oa *OCIArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
 	objs := []interface{}{}
 
 	// TODO: Not applicable to PipelineRuns, should look into a better way to separate this out
@@ -158,7 +158,7 @@ func (oa *OCIArtifact) ExtractObjects(obj objects.K8sObject) []interface{} {
 	return objs
 }
 
-func ExtractOCIImagesFromResults(obj objects.K8sObject, logger *zap.SugaredLogger) []interface{} {
+func ExtractOCIImagesFromResults(obj objects.TektonObject, logger *zap.SugaredLogger) []interface{} {
 	taskResultImages := map[string]*image{}
 	var objs []interface{}
 	urlSuffix := "IMAGE_URL"

--- a/pkg/artifacts/signable_test.go
+++ b/pkg/artifacts/signable_test.go
@@ -38,7 +38,7 @@ func TestOCIArtifact_ExtractObjects(t *testing.T) {
 
 	tests := []struct {
 		name string
-		obj  objects.K8sObject
+		obj  objects.TektonObject
 		want []interface{}
 	}{
 		{

--- a/pkg/chains/annotations_test.go
+++ b/pkg/chains/annotations_test.go
@@ -52,14 +52,14 @@ func TestReconciled(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			tr := &v1beta1.TaskRun{
+			tro := objects.NewTaskRunObject(&v1beta1.TaskRun{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: map[string]string{
 						ChainsAnnotation: tt.annotation,
 					},
 				},
-			}
-			got := Reconciled(tr)
+			})
+			got := Reconciled(tro)
 			if got != tt.want {
 				t.Errorf("Reconciled() got = %v, want %v", got, tt.want)
 			}

--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -37,7 +37,7 @@ func GenerateAttestation(builderID string, pr *v1beta1.PipelineRun, logger *zap.
 	// We don't need to pass in a client/context here, as we only want access to the original object
 	// Need a better way to differentiate between an abstracted original k8s object and getting the latest values
 	// - Possibly pass client and context in each method call instead of adding it to the struct?
-	pro := objects.NewPipelineRunObject(pr, nil, nil)
+	pro := objects.NewPipelineRunObject(pr)
 	subjects := util.GetSubjectDigests(pro, logger)
 
 	att := intoto.ProvenanceStatement{

--- a/pkg/chains/formats/intotoite6/util/utils.go
+++ b/pkg/chains/formats/intotoite6/util/utils.go
@@ -25,7 +25,7 @@ const (
 
 // GetSubjectDigests extracts OCI images from the TaskRun based on standard hinting set up
 // It also goes through looking for any PipelineResources of Image type
-func GetSubjectDigests(obj objects.K8sObject, logger *zap.SugaredLogger) []intoto.Subject {
+func GetSubjectDigests(obj objects.TektonObject, logger *zap.SugaredLogger) []intoto.Subject {
 	var subjects []intoto.Subject
 	imgs := artifacts.ExtractOCIImagesFromResults(obj, logger)
 	for _, i := range imgs {

--- a/pkg/chains/rekor.go
+++ b/pkg/chains/rekor.go
@@ -80,7 +80,7 @@ var getRekor = func(url string, l *zap.SugaredLogger) (rekorClient, error) {
 	}, nil
 }
 
-func shouldUploadTlog(cfg config.Config, obj objects.K8sObject) bool {
+func shouldUploadTlog(cfg config.Config, obj objects.TektonObject) bool {
 	// if transparency isn't enabled, return false
 	if !cfg.Transparency.Enabled {
 		return false
@@ -91,12 +91,11 @@ func shouldUploadTlog(cfg config.Config, obj objects.K8sObject) bool {
 	}
 
 	// Already uploaded, don't do it again
-	ann := obj.GetAnnotation(ChainsTransparencyAnnotation)
-	if ann.Ok {
+	if _, ok := obj.GetAnnotations()[ChainsTransparencyAnnotation]; ok {
 		return false
 	}
 
 	// verify the annotation
-	ann = obj.GetAnnotation(RekorAnnotation)
-	return ann.Value == "true"
+	ann := obj.GetAnnotations()[RekorAnnotation]
+	return ann == "true"
 }

--- a/pkg/chains/signing.go
+++ b/pkg/chains/signing.go
@@ -40,10 +40,10 @@ import (
 
 // TODO: Unclear why an interface is defined here.
 type Signer interface {
-	Sign(ctx context.Context, obj interface{}) error
+	Sign(ctx context.Context, obj objects.TektonObject) error
 }
 
-type TaskRunSigner struct {
+type ObjectSigner struct {
 	// Formatters: format payload
 	// The keys are the names of different formatters {tekton, in-toto, simplesigning}. The first two are for TaskRun artifact, and simplesigning is for OCI artifact.
 	// The values are actual `Payloader` interfaces that can generate payload in different format from taskrun.
@@ -118,19 +118,33 @@ func AllFormatters(cfg config.Config, l *zap.SugaredLogger) map[formats.PayloadT
 	return all
 }
 
-// SignTaskRun signs a TaskRun, and marks it as signed.
-func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
+// TODO: Hook this up to config.
+func getSignableTypes(obj objects.TektonObject, logger *zap.SugaredLogger) ([]artifacts.Signable, error) {
+	switch v := obj.GetObject().(type) {
+	case *v1beta1.TaskRun:
+		return []artifacts.Signable{
+			&artifacts.TaskRunArtifact{Logger: logger},
+			&artifacts.OCIArtifact{Logger: logger},
+		}, nil
+	case *v1beta1.PipelineRun:
+		return []artifacts.Signable{
+			&artifacts.PipelineRunArtifact{Logger: logger},
+		}, nil
+	default:
+		return nil, fmt.Errorf("unsupported type of object to be signed: %s", v)
+	}
+}
+
+// Signs TaskRun and PipelineRun objects, as well as generates attesations for each
+// Follows process of extract payload, sign payload, store payload and signature
+func (ts *ObjectSigner) Sign(ctx context.Context, tektonObj objects.TektonObject) error {
 	cfg := *config.FromContext(ctx)
 	logger := logging.FromContext(ctx)
 
-	// TODO: Hook this up to config.
-	enabledSignableTypes := []artifacts.Signable{
-		&artifacts.TaskRunArtifact{Logger: logger},
-		&artifacts.OCIArtifact{Logger: logger},
+	signableTypes, err := getSignableTypes(tektonObj, logger)
+	if err != nil {
+		return err
 	}
-
-	tr := object.(*v1beta1.TaskRun)
-	trObj := objects.NewTaskRunObject(tr)
 
 	signers := allSigners(ctx, ts.SecretPath, cfg, logger)
 
@@ -141,7 +155,7 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 
 	var merr *multierror.Error
 	extraAnnotations := map[string]string{}
-	for _, signableType := range enabledSignableTypes {
+	for _, signableType := range signableTypes {
 		if !signableType.Enabled(cfg) {
 			continue
 		}
@@ -150,13 +164,13 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 		payloader, ok := ts.Formatters[payloadFormat]
 
 		if !ok {
-			logger.Warnf("Format %s configured for TaskRun: %v %s was not found", payloadFormat, tr, signableType.Type())
+			logger.Warnf("Format %s configured for %s: %v was not found", payloadFormat, tektonObj.GetKind(), signableType.Type())
 			continue
 		}
 
 		// Extract all the "things" to be signed.
 		// We might have a few of each type (several binaries, or images)
-		objects := signableType.ExtractObjects(trObj)
+		objects := signableType.ExtractObjects(tektonObj)
 
 		// Go through each object one at a time.
 		for _, obj := range objects {
@@ -166,7 +180,7 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 				logger.Error(err)
 				continue
 			}
-			logger.Infof("Created payload of type %s for TaskRun %s/%s", string(payloadFormat), tr.Namespace, tr.Name)
+			logger.Infof("Created payload of type %s for %s %s/%s", string(payloadFormat), tektonObj.GetKind(), tektonObj.GetNamespace(), tektonObj.GetName())
 
 			// Sign it!
 			signerType := signableType.Signer(cfg)
@@ -207,13 +221,13 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 					Chain:         signer.Chain(),
 					PayloadFormat: payloadFormat,
 				}
-				if err := b.StorePayload(ctx, ts.Pipelineclientset, trObj, rawPayload, string(signature), storageOpts); err != nil {
+				if err := b.StorePayload(ctx, ts.Pipelineclientset, tektonObj, rawPayload, string(signature), storageOpts); err != nil {
 					logger.Error(err)
 					merr = multierror.Append(merr, err)
 				}
 			}
 
-			if shouldUploadTlog(cfg, trObj) {
+			if shouldUploadTlog(cfg, tektonObj) {
 				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
 				if err != nil {
 					merr = multierror.Append(merr, err)
@@ -225,7 +239,7 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 			}
 		}
 		if merr.ErrorOrNil() != nil {
-			if err := HandleRetry(ctx, trObj, ts.Pipelineclientset, extraAnnotations); err != nil {
+			if err := HandleRetry(ctx, tektonObj, ts.Pipelineclientset, extraAnnotations); err != nil {
 				merr = multierror.Append(merr, err)
 			}
 			return merr
@@ -233,145 +247,10 @@ func (ts *TaskRunSigner) Sign(ctx context.Context, object interface{}) error {
 	}
 
 	// Now mark the TaskRun as signed
-	return MarkSigned(ctx, trObj, ts.Pipelineclientset, extraAnnotations)
+	return MarkSigned(ctx, tektonObj, ts.Pipelineclientset, extraAnnotations)
 }
 
-type PipelineRunSigner struct {
-	// Formatters: format payload
-	// The keys are the names of different formatters {tekton, in-toto, simplesigning}. The first two are for TaskRun artifact, and simplesigning is for OCI artifact.
-	// The values are actual `Payloader` interfaces that can generate payload in different format from taskrun.
-	Formatters map[formats.PayloadType]formats.Payloader
-
-	// Backends: store payload and signature
-	// The keys are different storage option's name. {docdb, gcs, grafeas, oci, tekton}
-	// The values are the actual storage backends that will be used to store and retrieve provenance.
-	Backends          map[string]storage.Backend
-	Pipelineclientset versioned.Interface
-	SecretPath        string
-}
-
-// SignPipelineRun signs a PipelineRun, and marks it as signed.
-// TODO: Alot of overlap with TaskRunSigner.Sign, could probably merge them and pass a generic objects.K8sObject
-func (ps *PipelineRunSigner) Sign(ctx context.Context, object interface{}) error {
-	// Get all the things we might need (storage backends, signers and formatters)
-	cfg := *config.FromContext(ctx)
-	logger := logging.FromContext(ctx)
-
-	enabledSignableTypes := []artifacts.Signable{
-		&artifacts.PipelineRunArtifact{Logger: logger},
-	}
-
-	pr := object.(*v1beta1.PipelineRun)
-	prObj := objects.NewPipelineRunObject(pr, ps.Pipelineclientset, ctx)
-
-	signers := allSigners(ctx, ps.SecretPath, cfg, logger)
-
-	rekorClient, err := getRekor(cfg.Transparency.URL, logger)
-	if err != nil {
-		return err
-	}
-
-	// TODO: Find things to sign and sign them, probably just the PipelineRun resource itself?
-	// This is where the bulk of the work will reside. Things to consider:
-	// 	* Should this sign any images that were produced by the pipeline? Or should we let
-	//	  the existing mechanisms do that (based on TaskRuns)?
-	//	* If backend is oci, should the PipelineRun attestation be pushed to every repo where
-	//	  an image was pushed? Would this conflict with attestations pushed by SignTaskRun?
-	//	* Implement retries and all that jazz found in SignTaskRun
-	var merr *multierror.Error
-	extraAnnotations := map[string]string{}
-	for _, signableType := range enabledSignableTypes {
-		if !signableType.Enabled(cfg) {
-			continue
-		}
-		payloadFormat := signableType.PayloadFormat(cfg)
-		payloader, ok := ps.Formatters[payloadFormat]
-		if !ok {
-			logger.Warnf("Format %s configured for PipelineRun: %v %s was not found", payloadFormat, pr, signableType.Type())
-			continue
-		}
-
-		objects := signableType.ExtractObjects(prObj)
-
-		for _, obj := range objects {
-			payload, err := payloader.CreatePayload(obj)
-			if err != nil {
-				logger.Infof("Error creating payload")
-				logger.Error(err)
-				continue
-			}
-			logger.Infof("Created payload of type %s for Pipelinerun %s/%s", string(payloadFormat), pr.Namespace, pr.Name)
-
-			// Sign it!
-			signerType := signableType.Signer(cfg)
-			signer, ok := signers[signerType]
-			if !ok {
-				logger.Warnf("No signer %s configured for %s", signerType, signableType.Type())
-				continue
-			}
-
-			if payloader.Wrap() {
-				wrapped, err := signing.Wrap(ctx, signer)
-				if err != nil {
-					return err
-				}
-				logger.Infof("Using wrapped envelope signer for %s", payloader.Type())
-				signer = wrapped
-			}
-
-			logger.Infof("Signing object with %s", signerType)
-			rawPayload, err := json.Marshal(payload)
-			if err != nil {
-				logger.Warnf("Unable to marshal payload: %v", signerType, obj)
-				continue
-			}
-
-			signature, err := signer.SignMessage(bytes.NewReader(rawPayload))
-			if err != nil {
-				logger.Error(err)
-				continue
-			}
-
-			// Now store those!
-			for _, backend := range signableType.StorageBackend(cfg).List() {
-				b := ps.Backends[backend]
-				storageOpts := config.StorageOpts{
-					Key:           signableType.Key(obj),
-					Cert:          signer.Cert(),
-					Chain:         signer.Chain(),
-					PayloadFormat: payloadFormat,
-				}
-				if err := b.StorePayload(ctx, ps.Pipelineclientset, prObj, rawPayload, string(signature), storageOpts); err != nil {
-					logger.Error(err)
-					merr = multierror.Append(merr, err)
-				}
-			}
-
-			if shouldUploadTlog(cfg, prObj) {
-				entry, err := rekorClient.UploadTlog(ctx, signer, signature, rawPayload, signer.Cert(), string(payloadFormat))
-				if err != nil {
-					logger.Error(err)
-					merr = multierror.Append(merr, err)
-				} else {
-					logger.Infof("Uploaded entry to %s with index %d", cfg.Transparency.URL, *entry.LogIndex)
-
-					extraAnnotations[ChainsTransparencyAnnotation] = fmt.Sprintf("%s/api/v1/log/entries?logIndex=%d", cfg.Transparency.URL, *entry.LogIndex)
-				}
-			}
-		}
-		if merr.ErrorOrNil() != nil {
-			if err := HandleRetry(ctx, prObj, ps.Pipelineclientset, extraAnnotations); err != nil {
-				merr = multierror.Append(merr, err)
-			}
-			return merr
-		}
-	}
-
-	// Now mark the PipelineRun as signed
-	return MarkSigned(ctx, prObj, ps.Pipelineclientset, extraAnnotations)
-}
-
-func HandleRetry(ctx context.Context, obj objects.K8sObject, ps versioned.Interface, annotations map[string]string) error {
+func HandleRetry(ctx context.Context, obj objects.TektonObject, ps versioned.Interface, annotations map[string]string) error {
 	if RetryAvailable(obj) {
 		return AddRetry(ctx, obj, ps, annotations)
 	}

--- a/pkg/chains/storage/docdb/docdb.go
+++ b/pkg/chains/storage/docdb/docdb.go
@@ -62,7 +62,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 }
 
 // StorePayload implements the Payloader interface.
-func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, _ objects.TektonObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	var obj interface{}
 	if err := json.Unmarshal(rawPayload, &obj); err != nil {
 		return err
@@ -88,7 +88,7 @@ func (b *Backend) Type() string {
 	return StorageTypeDocDB
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.TektonObject, opts config.StorageOpts) (map[string][]string, error) {
 	// Retrieve the document.
 	documents, err := b.retrieveDocuments(ctx, opts)
 	if err != nil {
@@ -107,7 +107,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface,
 	return m, nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.TektonObject, opts config.StorageOpts) (map[string]string, error) {
 	documents, err := b.retrieveDocuments(ctx, opts)
 	if err != nil {
 		return nil, err

--- a/pkg/chains/storage/gcs/gcs.go
+++ b/pkg/chains/storage/gcs/gcs.go
@@ -62,7 +62,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 }
 
 // StorePayload implements the storage.Backend interface.
-func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// We need multiple objects: the signature and the payload. We want to make these unique to the UID, but easy to find based on the
@@ -145,7 +145,7 @@ func (r *reader) GetReader(ctx context.Context, object string) (io.ReadCloser, e
 	return r.client.Bucket(r.bucket).Object(object).NewReader(ctx)
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, opts config.StorageOpts) (map[string][]string, error) {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	object := sigName(tr, opts)
@@ -159,7 +159,7 @@ func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface,
 	return m, nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, opts config.StorageOpts) (map[string]string, error) {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	object := payloadName(tr, opts)

--- a/pkg/chains/storage/grafeas/grafeas.go
+++ b/pkg/chains/storage/grafeas/grafeas.go
@@ -85,7 +85,7 @@ func NewStorageBackend(ctx context.Context, logger *zap.SugaredLogger, cfg confi
 }
 
 // StorePayload implements the storage.Backend interface.
-func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// TODO: Gracefully handle unexpected type
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// We only support simplesigning for OCI images, and in-toto for taskrun.
@@ -128,7 +128,7 @@ func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj o
 }
 
 // Retrieve payloads from grafeas server and store it in a map
-func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, opts config.StorageOpts) (map[string]string, error) {
 	// TODO: Gracefully handle unexpected type
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// initialize an empty map for result
@@ -153,7 +153,7 @@ func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, o
 }
 
 // Retrieve signatures from grafeas server and store it in a map
-func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, opts config.StorageOpts) (map[string][]string, error) {
 	// TODO: Gracefully handle unexpected type
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	// initialize an empty map for result

--- a/pkg/chains/storage/oci/oci_test.go
+++ b/pkg/chains/storage/oci/oci_test.go
@@ -161,7 +161,7 @@ func TestBackend_StorePayload(t *testing.T) {
 			trObj := objects.NewTaskRunObject(tt.fields.tr)
 			b := &Backend{
 				logger: logtesting.TestLogger(t),
-				getAuthenticator: func(_ context.Context, _ objects.K8sObject, _ kubernetes.Interface) (remote.Option, error) {
+				getAuthenticator: func(_ context.Context, _ objects.TektonObject, _ kubernetes.Interface) (remote.Option, error) {
 					return remote.WithAuthFromKeychain(authn.DefaultKeychain), nil
 				},
 			}

--- a/pkg/chains/storage/pubsub/pubsub.go
+++ b/pkg/chains/storage/pubsub/pubsub.go
@@ -54,7 +54,7 @@ func (b *Backend) Type() string {
 	return StorageBackendPubSub
 }
 
-func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
+func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj objects.TektonObject, rawPayload []byte, signature string, opts config.StorageOpts) error {
 	// TODO: Handle unsupported type gracefully
 	tr := obj.GetObject().(*v1beta1.TaskRun)
 	b.logger.Infof("Storing payload on TaskRun %s/%s", tr.Namespace, tr.Name)
@@ -85,11 +85,11 @@ func (b *Backend) StorePayload(ctx context.Context, _ versioned.Interface, obj o
 	return nil
 }
 
-func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string]string, error) {
+func (b *Backend) RetrievePayloads(ctx context.Context, _ versioned.Interface, _ objects.TektonObject, opts config.StorageOpts) (map[string]string, error) {
 	return nil, fmt.Errorf("not implemented for this storage backend: %s", b.Type())
 }
 
-func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.K8sObject, opts config.StorageOpts) (map[string][]string, error) {
+func (b *Backend) RetrieveSignatures(ctx context.Context, _ versioned.Interface, _ objects.TektonObject, opts config.StorageOpts) (map[string][]string, error) {
 	return nil, fmt.Errorf("not implemented for this storage backend: %s", b.Type())
 }
 

--- a/pkg/chains/storage/storage.go
+++ b/pkg/chains/storage/storage.go
@@ -31,11 +31,11 @@ import (
 
 // Backend is an interface to store a chains Payload
 type Backend interface {
-	StorePayload(ctx context.Context, clientSet versioned.Interface, obj objects.K8sObject, rawPayload []byte, signature string, opts config.StorageOpts) error
+	StorePayload(ctx context.Context, clientSet versioned.Interface, obj objects.TektonObject, rawPayload []byte, signature string, opts config.StorageOpts) error
 	// RetrievePayloads maps [ref]:[payload] for a TaskRun
-	RetrievePayloads(ctx context.Context, clientSet versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string]string, error)
+	RetrievePayloads(ctx context.Context, clientSet versioned.Interface, obj objects.TektonObject, opts config.StorageOpts) (map[string]string, error)
 	// RetrieveSignatures maps [ref]:[list of signatures] for a TaskRun
-	RetrieveSignatures(ctx context.Context, clientSet versioned.Interface, obj objects.K8sObject, opts config.StorageOpts) (map[string][]string, error)
+	RetrieveSignatures(ctx context.Context, clientSet versioned.Interface, obj objects.TektonObject, opts config.StorageOpts) (map[string][]string, error)
 	// Type is the string representation of the backend
 	Type() string
 }

--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -35,7 +35,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	kubeClient := kubeclient.Get(ctx)
 	pipelineClient := pipelineclient.Get(ctx)
 
-	psSigner := &chains.PipelineRunSigner{
+	psSigner := &chains.ObjectSigner{
 		SecretPath:        SecretPath,
 		Pipelineclientset: pipelineClient,
 	}

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	signing "github.com/tektoncd/chains/pkg/chains"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	pipelinerunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/pipelinerun"
 	"knative.dev/pkg/logging"
@@ -52,13 +53,15 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) 
 		logging.FromContext(ctx).Infof("pipelinerun %s/%s is still running", pr.Namespace, pr.Name)
 		return nil
 	}
+	pro := objects.NewPipelineRunObject(pr)
+
 	// Check to see if it has already been signed.
-	if signing.ReconciledPipelineRun(pr) {
+	if signing.Reconciled(pro) {
 		logging.FromContext(ctx).Infof("pipelinerun %s/%s has been reconciled", pr.Namespace, pr.Name)
 		return nil
 	}
 
-	if err := r.PipelineRunSigner.Sign(ctx, pr); err != nil {
+	if err := r.PipelineRunSigner.Sign(ctx, pro); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/taskrun/controller.go
+++ b/pkg/reconciler/taskrun/controller.go
@@ -35,7 +35,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 	kubeClient := kubeclient.Get(ctx)
 	pipelineClient := pipelineclient.Get(ctx)
 
-	tsSigner := &chains.TaskRunSigner{
+	tsSigner := &chains.ObjectSigner{
 		SecretPath:        SecretPath,
 		Pipelineclientset: pipelineClient,
 	}

--- a/pkg/reconciler/taskrun/taskrun.go
+++ b/pkg/reconciler/taskrun/taskrun.go
@@ -17,6 +17,7 @@ import (
 	"context"
 
 	signing "github.com/tektoncd/chains/pkg/chains"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	taskrunreconciler "github.com/tektoncd/pipeline/pkg/client/injection/reconciler/pipeline/v1beta1/taskrun"
 	"knative.dev/pkg/logging"
@@ -52,13 +53,16 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, tr *v1beta1.TaskRun) pkgr
 		logging.FromContext(ctx).Infof("taskrun %s/%s is still running", tr.Namespace, tr.Name)
 		return nil
 	}
+
+	obj := objects.NewTaskRunObject(tr)
+
 	// Check to see if it has already been signed.
-	if signing.Reconciled(tr) {
+	if signing.Reconciled(obj) {
 		logging.FromContext(ctx).Infof("taskrun %s/%s has been reconciled", tr.Namespace, tr.Name)
 		return nil
 	}
 
-	if err := r.TaskRunSigner.Sign(ctx, tr); err != nil {
+	if err := r.TaskRunSigner.Sign(ctx, obj); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/reconciler/taskrun/taskrun_test.go
+++ b/pkg/reconciler/taskrun/taskrun_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	signing "github.com/tektoncd/chains/pkg/chains"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	informers "github.com/tektoncd/pipeline/pkg/client/informers/externalversions/pipeline/v1beta1"
@@ -170,7 +171,7 @@ type mockSigner struct {
 	pipelineRunSigned bool
 }
 
-func (m *mockSigner) Sign(ctx context.Context, obj interface{}) error {
+func (m *mockSigner) Sign(ctx context.Context, obj objects.TektonObject) error {
 	m.taskRunSigned = true
 	m.pipelineRunSigned = true
 	return nil


### PR DESCRIPTION
Following upstreams lead on abstracting away Kubernetes objects.
Ref: https://github.com/tektoncd/results/blob/main/pkg/watcher/results/results.go#L58

- Combining the `TaskrunSigner` and `PipelinerunSigner`
- Renaming `k8sObject` to `TektonObject`
- Refactoring calls to `TektonObject` to use methods inherited by a generic Kubernetes object:
    ```
    type Object interface {
	    metav1.Object
	    runtime.Object
    }
    ```
    This allows us to reuse most metadata and runtime fields common to all objects.
