### PR TITLE
Handle missing .status.pipelineSpec attribute

### DIFF
--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -75,6 +75,9 @@ func buildConfig(pr *v1beta1.PipelineRun, logger *zap.SugaredLogger) BuildConfig
 	}
 
 	pSpec := pr.Status.PipelineSpec
+	if pSpec == nil {
+		return BuildConfig{}
+	}
 	pipelineTasks := append(pSpec.Tasks, pSpec.Finally...)
 
 	var last string


### PR DESCRIPTION
If a pipelinerun references a pipeline from a bundle, and that pipeline
does not exist in the bundle, the .status.pipelineSpec attribute is
never populated on the pipelinerun.

To reproduce the issue create the following resource:
```
apiVersion: tekton.dev/v1beta1
kind: PipelineRun
metadata:
  name: cosign-verify-kcgkn
spec:
  params:
  - name: IMAGE_REF
    value: image-registry.openshift-image-registry.svc:5000/tekton-chains/buildah-demo-mijduiirbs@sha256:141ead516e4855b74fc1938961fe810bf0d2003b5c9061ba17511648ebf3cea0
  - name: PUBLIC_KEY
    value: k8s://tekton-chains/signing-secrets
  pipelineRef:
    bundle: quay.io/redhat-appstudio/hacbs-templates-bundle:861e28f4eb2380fd1531ee30a9e74fb6ce496b9f
    name: e2e-ec
```

Signed-off-by: Luiz Carvalho <lucarval@redhat.com>