### PR TITLE
Prevent race condition when using taskrun and pipelinerun attestation

### DIFF
--- a/pkg/reconciler/pipelinerun/controller.go
+++ b/pkg/reconciler/pipelinerun/controller.go
@@ -42,6 +42,7 @@ func NewController(ctx context.Context, cmw configmap.Watcher) *controller.Impl 
 
 	c := &Reconciler{
 		PipelineRunSigner: psSigner,
+		Pipelineclientset: pipelineClient,
 	}
 	impl := pipelinerunreconciler.NewImpl(ctx, c, func(impl *controller.Impl) controller.Options {
 		cfgStore := config.NewConfigStore(logger, func(name string, value interface{}) {

--- a/pkg/reconciler/pipelinerun/pipelinerun.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun.go
@@ -76,6 +76,12 @@ func (r *Reconciler) FinalizeKind(ctx context.Context, pr *v1beta1.PipelineRun) 
 				name, pr.Namespace, pr.Name)
 			return nil
 		}
+	}
+
+	// Signing both taskruns and pipelineruns causes a race condition when using oci storage
+	// during the push to the registry. This checks the taskruns to ensure they've been reconciled
+	// before attempting to sign the pippelinerun
+	for name, _ := range pr.Status.TaskRuns {
 		reconciled, err := isTaskRunReconciled(ctx, r.Pipelineclientset, pr.Namespace, name)
 		if err != nil {
 			logging.FromContext(ctx).Errorf(


### PR DESCRIPTION
If the last task in the pipeline is the one that builds an image (thus provides the expected type-hinting), there's a race condition which causes either the taskrun or the pipelinerun attestation to be present in the registry. This change confirms the taskruns have been reconciled in chains before reconciling the pipelinerun.