### PR TITLE
Supporting PipelineRun childRefs

### DIFF
--- a/pkg/artifacts/signable.go
+++ b/pkg/artifacts/signable.go
@@ -43,13 +43,12 @@ type TaskRunArtifact struct {
 }
 
 func (ta *TaskRunArtifact) Key(obj interface{}) string {
-	tr := obj.(*v1beta1.TaskRun)
-	return "taskrun-" + string(tr.UID)
+	tro := obj.(*objects.TaskRunObject)
+	return "taskrun-" + string(tro.UID)
 }
 
 func (ta *TaskRunArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
-	tr := obj.GetObject().(*v1beta1.TaskRun)
-	return []interface{}{tr}
+	return []interface{}{obj}
 }
 
 func (ta *TaskRunArtifact) Type() string {
@@ -77,13 +76,12 @@ type PipelineRunArtifact struct {
 }
 
 func (pa *PipelineRunArtifact) Key(obj interface{}) string {
-	pr := obj.(*v1beta1.PipelineRun)
-	return "pipelinerun-" + string(pr.UID)
+	pro := obj.(*objects.PipelineRunObject)
+	return "pipelinerun-" + string(pro.UID)
 }
 
 func (pa *PipelineRunArtifact) ExtractObjects(obj objects.TektonObject) []interface{} {
-	pr := obj.GetObject().(*v1beta1.PipelineRun)
-	return []interface{}{pr}
+	return []interface{}{obj}
 }
 
 func (pa *PipelineRunArtifact) Type() string {

--- a/pkg/chains/formats/intotoite6/intotoite6.go
+++ b/pkg/chains/formats/intotoite6/intotoite6.go
@@ -22,8 +22,8 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats"
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/taskrun"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
 )
 
@@ -45,9 +45,9 @@ func (i *InTotoIte6) Wrap() bool {
 
 func (i *InTotoIte6) CreatePayload(obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
-	case *v1beta1.TaskRun:
+	case *objects.TaskRunObject:
 		return taskrun.GenerateAttestation(i.builderID, v, i.logger)
-	case *v1beta1.PipelineRun:
+	case *objects.PipelineRunObject:
 		return pipelinerun.GenerateAttestation(i.builderID, v, i.logger)
 	default:
 		return nil, fmt.Errorf("intoto does not support type: %s", v)

--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/pipelinerun"
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/taskrun"
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/util"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/chains/pkg/config"
 
 	"github.com/google/go-cmp/cmp"
@@ -109,7 +110,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 	}
 	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
 
-	got, err := i.CreatePayload(tr)
+	got, err := i.CreatePayload(objects.NewTaskRunObject(tr))
 
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -120,7 +121,7 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 }
 
 func TestPipelineRunCreatePayload(t *testing.T) {
-	tr, err := util.PipelinerunFromFile("testdata/pipelinerun1.json")
+	pr, err := util.PipelinerunFromFile("testdata/pipelinerun1.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -184,8 +185,8 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								EntryPoint: "git clone",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"container": "clone",
-									"image":     "test.io/test/clone-image",
+									"container": "step1",
+									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 								Annotations: nil,
 							},
@@ -199,17 +200,17 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						},
 						Results: []v1beta1.TaskRunResult{
 							{
-								Name: "commit",
+								Name: "some-uri_DIGEST",
 								Value: v1beta1.ArrayOrString{
 									Type:      v1beta1.ParamTypeString,
-									StringVal: "abcd",
+									StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
 								},
 							},
 							{
-								Name: "url",
+								Name: "some-uri",
 								Value: v1beta1.ArrayOrString{
 									Type:      v1beta1.ParamTypeString,
-									StringVal: "https://git.test.com",
+									StringVal: "pkg:deb/debian/curl@7.50.3-1",
 								},
 							},
 						},
@@ -226,11 +227,29 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						Status:     "Succeeded",
 						Steps: []util.StepAttestation{
 							{
-								EntryPoint: "buildah build",
+								EntryPoint: "",
 								Arguments:  []string(nil),
 								Environment: map[string]interface{}{
-									"image":     "test.io/test/build-image",
-									"container": "build",
+									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"container": "step1",
+								},
+								Annotations: nil,
+							},
+							{
+								EntryPoint: "",
+								Arguments:  []string(nil),
+								Environment: map[string]interface{}{
+									"image":     "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+									"container": "step2",
+								},
+								Annotations: nil,
+							},
+							{
+								EntryPoint: "",
+								Arguments:  []string(nil),
+								Environment: map[string]interface{}{
+									"image":     "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+									"container": "step3",
 								},
 								Annotations: nil,
 							},
@@ -254,7 +273,7 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 								Name: "IMAGE_URL",
 								Value: v1beta1.ArrayOrString{
 									Type:      v1beta1.ParamTypeString,
-									StringVal: "test.io/test/image\n",
+									StringVal: "gcr.io/my/image",
 								},
 							},
 						},
@@ -263,10 +282,206 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 			},
 		},
 	}
+
+	tr1, err := util.TaskrunFromFile("testdata/taskrun1.json")
+	if err != nil {
+		t.Errorf("error reading taskrun1: %s", err.Error())
+	}
+	tr2, err := util.TaskrunFromFile("testdata/taskrun2.json")
+	if err != nil {
+		t.Errorf("error reading taskrun: %s", err.Error())
+	}
+	pro := objects.NewPipelineRunObject(pr)
+	pro.AppendTaskRun(tr1)
+	pro.AppendTaskRun(tr2)
+
 	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
 
-	got, err := i.CreatePayload(tr)
+	got, err := i.CreatePayload(pro)
+	if err != nil {
+		t.Errorf("unexpected error: %s", err.Error())
+	}
+	if diff := cmp.Diff(expected, got); diff != "" {
+		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
+	}
+}
+func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
+	pr, err := util.PipelinerunFromFile("testdata/pipelinerun-childrefs.json")
+	if err != nil {
+		t.Fatal(err)
+	}
 
+	cfg := config.Config{
+		Builder: config.BuilderConfig{
+			ID: "test_builder-1",
+		},
+	}
+	expected := in_toto.ProvenanceStatement{
+		StatementHeader: in_toto.StatementHeader{
+			Type:          in_toto.StatementInTotoV01,
+			PredicateType: slsa.PredicateSLSAProvenance,
+			Subject: []in_toto.Subject{
+				{
+					Name: "test.io/test/image",
+					Digest: slsa.DigestSet{
+						"sha256": "827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+					},
+				},
+			},
+		},
+		Predicate: slsa.ProvenancePredicate{
+			Metadata: &slsa.ProvenanceMetadata{
+				BuildStartedOn:  &e1BuildStart,
+				BuildFinishedOn: &e1BuildFinished,
+				Completeness: slsa.ProvenanceComplete{
+					Parameters:  false,
+					Environment: false,
+					Materials:   false,
+				},
+				Reproducible: false,
+			},
+			Materials: []slsa.ProvenanceMaterial{
+				{URI: "git+https://git.test.com.git", Digest: slsa.DigestSet{"sha1": "abcd"}},
+			},
+			Invocation: slsa.ProvenanceInvocation{
+				ConfigSource: slsa.ConfigSource{},
+				Parameters: map[string]v1beta1.ArrayOrString{
+					"IMAGE": {Type: "string", StringVal: "test.io/test/image"},
+				},
+			},
+			Builder: slsa.ProvenanceBuilder{
+				ID: "test_builder-1",
+			},
+			BuildType: "https://tekton.dev/attestations/chains/pipelinerun@v2",
+			BuildConfig: pipelinerun.BuildConfig{
+				Tasks: []pipelinerun.TaskAttestation{
+					{
+						Name:  "git-clone",
+						After: nil,
+						Ref: v1beta1.TaskRef{
+							Name: "git-clone",
+							Kind: "ClusterTask",
+						},
+						StartedOn:  e1BuildStart,
+						FinishedOn: e1BuildFinished,
+						Status:     "Succeeded",
+						Steps: []util.StepAttestation{
+							{
+								EntryPoint: "git clone",
+								Arguments:  []string(nil),
+								Environment: map[string]interface{}{
+									"container": "step1",
+									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+								},
+								Annotations: nil,
+							},
+						},
+						Invocation: slsa.ProvenanceInvocation{
+							ConfigSource: slsa.ConfigSource{},
+							Parameters: map[string]v1beta1.ArrayOrString{
+								"revision": {Type: "string", StringVal: ""},
+								"url":      {Type: "string", StringVal: "https://git.test.com"},
+							},
+						},
+						Results: []v1beta1.TaskRunResult{
+							{
+								Name: "some-uri_DIGEST",
+								Value: v1beta1.ArrayOrString{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+								},
+							},
+							{
+								Name: "some-uri",
+								Value: v1beta1.ArrayOrString{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "pkg:deb/debian/curl@7.50.3-1",
+								},
+							},
+						},
+					},
+					{
+						Name:  "build",
+						After: []string{"git-clone"},
+						Ref: v1beta1.TaskRef{
+							Name: "build",
+							Kind: "ClusterTask",
+						},
+						StartedOn:  e1BuildStart,
+						FinishedOn: e1BuildFinished,
+						Status:     "Succeeded",
+						Steps: []util.StepAttestation{
+							{
+								EntryPoint: "",
+								Arguments:  []string(nil),
+								Environment: map[string]interface{}{
+									"image":     "docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6",
+									"container": "step1",
+								},
+								Annotations: nil,
+							},
+							{
+								EntryPoint: "",
+								Arguments:  []string(nil),
+								Environment: map[string]interface{}{
+									"image":     "docker-pullable://gcr.io/test2/test2@sha256:4d6dd704ef58cb214dd826519929e92a978a57cdee43693006139c0080fd6fac",
+									"container": "step2",
+								},
+								Annotations: nil,
+							},
+							{
+								EntryPoint: "",
+								Arguments:  []string(nil),
+								Environment: map[string]interface{}{
+									"image":     "docker-pullable://gcr.io/test3/test3@sha256:f1a8b8549c179f41e27ff3db0fe1a1793e4b109da46586501a8343637b1d0478",
+									"container": "step3",
+								},
+								Annotations: nil,
+							},
+						},
+						Invocation: slsa.ProvenanceInvocation{
+							ConfigSource: slsa.ConfigSource{},
+							Parameters: map[string]v1beta1.ArrayOrString{
+								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "$(tasks.git-clone.results.commit)"},
+								"CHAINS-GIT_URL":    {Type: "string", StringVal: "$(tasks.git-clone.results.url)"},
+							},
+						},
+						Results: []v1beta1.TaskRunResult{
+							{
+								Name: "IMAGE_DIGEST",
+								Value: v1beta1.ArrayOrString{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7",
+								},
+							},
+							{
+								Name: "IMAGE_URL",
+								Value: v1beta1.ArrayOrString{
+									Type:      v1beta1.ParamTypeString,
+									StringVal: "gcr.io/my/image",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	tr1, err := util.TaskrunFromFile("testdata/taskrun1.json")
+	if err != nil {
+		t.Errorf("error reading taskrun1: %s", err.Error())
+	}
+	tr2, err := util.TaskrunFromFile("testdata/taskrun2.json")
+	if err != nil {
+		t.Errorf("error reading taskrun: %s", err.Error())
+	}
+	pro := objects.NewPipelineRunObject(pr)
+	pro.AppendTaskRun(tr1)
+	pro.AppendTaskRun(tr2)
+
+	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
+	got, err := i.CreatePayload(pro)
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
@@ -293,7 +508,10 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			Subject:       nil,
 		},
 		Predicate: slsa.ProvenancePredicate{
-			Metadata: &slsa.ProvenanceMetadata{},
+			Metadata: &slsa.ProvenanceMetadata{
+				BuildStartedOn:  &e1BuildStart,
+				BuildFinishedOn: &e1BuildFinished,
+			},
 			Builder: slsa.ProvenanceBuilder{
 				ID: "test_builder-2",
 			},
@@ -304,7 +522,8 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 			BuildConfig: taskrun.BuildConfig{
 				Steps: []util.StepAttestation{
 					{
-						Arguments: []string(nil),
+						EntryPoint: "git clone",
+						Arguments:  []string(nil),
 						Environment: map[string]interface{}{
 							"container": string("step1"),
 							"image":     string("docker-pullable://gcr.io/test1/test1@sha256:d4b63d3e24d6eef04a6dc0795cf8a73470688803d97c52cffa3c8d4efd3397b6"),
@@ -315,7 +534,7 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 		},
 	}
 	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
-	got, err := i.CreatePayload(tr)
+	got, err := i.CreatePayload(objects.NewTaskRunObject(tr))
 
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
@@ -339,13 +558,13 @@ func TestCreatePayloadNilTaskRef(t *testing.T) {
 	}
 	f, _ := NewFormatter(cfg, logtesting.TestLogger(t))
 
-	p, err := f.CreatePayload(tr)
+	p, err := f.CreatePayload(objects.NewTaskRunObject(tr))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}
 
 	ps := p.(in_toto.ProvenanceStatement)
-	if diff := cmp.Diff(tr.Name, ps.Predicate.Invocation.ConfigSource.EntryPoint); diff != "" {
+	if diff := cmp.Diff("", ps.Predicate.Invocation.ConfigSource.EntryPoint); diff != "" {
 		t.Errorf("InTotoIte6.CreatePayload(): -want +got: %s", diff)
 	}
 }
@@ -403,7 +622,7 @@ func TestMultipleSubjects(t *testing.T) {
 	}
 
 	i, _ := NewFormatter(cfg, logtesting.TestLogger(t))
-	got, err := i.CreatePayload(tr)
+	got, err := i.CreatePayload(objects.NewTaskRunObject(tr))
 	if err != nil {
 		t.Errorf("unexpected error: %s", err.Error())
 	}

--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -9,7 +9,6 @@ import (
 	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 	"go.uber.org/zap"
-
 	corev1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
 )

--- a/pkg/chains/formats/intotoite6/taskrun/buildconfig.go
+++ b/pkg/chains/formats/intotoite6/taskrun/buildconfig.go
@@ -18,6 +18,7 @@ package taskrun
 
 import (
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/util"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
@@ -35,18 +36,18 @@ type Step struct {
 	Annotations map[string]string `json:"annotations"`
 }
 
-func buildConfig(tr *v1beta1.TaskRun) BuildConfig {
+func buildConfig(tro *objects.TaskRunObject) BuildConfig {
 	attestations := []util.StepAttestation{}
-	for _, stepState := range tr.Status.Steps {
-		step := stepFromTaskRun(stepState.Name, tr)
+	for _, stepState := range tro.Status.Steps {
+		step := stepFromTaskRun(stepState.Name, tro)
 		attestations = append(attestations, util.AttestStep(step, &stepState))
 	}
 	return BuildConfig{Steps: attestations}
 }
 
-func stepFromTaskRun(name string, tr *v1beta1.TaskRun) *v1beta1.Step {
-	if tr.Status.TaskSpec != nil {
-		for _, s := range tr.Status.TaskSpec.Steps {
+func stepFromTaskRun(name string, tro *objects.TaskRunObject) *v1beta1.Step {
+	if tro.Status.TaskSpec != nil {
+		for _, s := range tro.Status.TaskSpec.Steps {
 			if s.Name == name {
 				return &s
 			}

--- a/pkg/chains/formats/intotoite6/taskrun/buildconfig_test.go
+++ b/pkg/chains/formats/intotoite6/taskrun/buildconfig_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/google/go-cmp/cmp"
 	"github.com/tektoncd/chains/pkg/chains/formats/intotoite6/util"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
@@ -82,7 +83,7 @@ status:
 		},
 	}
 
-	got := buildConfig(taskRun)
+	got := buildConfig(objects.NewTaskRunObject(taskRun))
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/chains/formats/intotoite6/taskrun/provenance_test.go
+++ b/pkg/chains/formats/intotoite6/taskrun/provenance_test.go
@@ -65,7 +65,7 @@ func TestMetadata(t *testing.T) {
 		BuildStartedOn:  &start,
 		BuildFinishedOn: &end,
 	}
-	got := metadata(tr)
+	got := metadata(objects.NewTaskRunObject(tr))
 	if !reflect.DeepEqual(expected, got) {
 		t.Fatalf("expected %v got %v", expected, got)
 	}
@@ -102,7 +102,7 @@ status:
 		},
 	}
 
-	got := materials(taskRun)
+	got := materials(objects.NewTaskRunObject(taskRun))
 	if !reflect.DeepEqual(expected, got) {
 		t.Fatalf("expected %v got %v", expected, got)
 	}
@@ -154,7 +154,7 @@ status:
 		},
 	}
 
-	got := materials(taskRun)
+	got := materials(objects.NewTaskRunObject(taskRun))
 	if !reflect.DeepEqual(expected, got) {
 		t.Fatalf("expected %v got %v", expected, got)
 	}
@@ -182,7 +182,7 @@ spec:
 		},
 	}
 
-	got = materials(taskRun)
+	got = materials(objects.NewTaskRunObject(taskRun))
 	if !reflect.DeepEqual(expected, got) {
 		t.Fatalf("expected %v got %v", expected, got)
 	}
@@ -255,7 +255,7 @@ status:
 		},
 	}
 
-	got := invocation(taskRun, logtesting.TestLogger(t))
+	got := invocation(objects.NewTaskRunObject(taskRun), logtesting.TestLogger(t))
 	if !reflect.DeepEqual(expected, got) {
 		if d := cmp.Diff(expected, got); d != "" {
 			t.Log(d)

--- a/pkg/chains/formats/intotoite6/testdata/pipelinerun-childrefs.json
+++ b/pkg/chains/formats/intotoite6/testdata/pipelinerun-childrefs.json
@@ -1,0 +1,129 @@
+{
+    "spec": {
+        "params": [
+            {
+                "name": "IMAGE",
+                "value": "test.io/test/image"
+            }
+        ],
+        "pipelineRef": {
+            "name": "test-pipeline"
+        },
+        "serviceAccountName": "pipeline"
+    },
+    "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
+        "conditions": [
+            {
+                "lastTransitionTime": "2021-03-29T09:50:15Z",
+                "message": "Tasks Completed: 2 (Failed: 0, Cancelled 0), Skipped: 0",
+                "reason": "Succeeded",
+                "status": "True",
+                "type": "Succeeded"
+            }
+        ],
+        "pipelineResults": [
+            {
+                "name": "CHAINS-GIT_COMMIT",
+                "value": "abcd"
+            },
+            {
+                "name": "CHAINS-GIT_URL",
+                "value": "https://git.test.com"
+            },
+            {
+                "name": "IMAGE_URL",
+                "value": "test.io/test/image"
+            },
+            {
+                "name": "IMAGE_DIGEST",
+                "value": "sha256:827521c857fdcd4374f4da5442fbae2edb01e7fbae285c3ec15673d4c1daecb7"
+            }
+        ],
+        "pipelineSpec": {
+            "params": [
+                {
+                    "description": "Image path on registry",
+                    "name": "IMAGE",
+                    "type": "string"
+                }
+            ],
+            "results": [
+                {
+                    "description": "",
+                    "name": "CHAINS-GIT_COMMIT",
+                    "value": "$(tasks.git-clone.results.commit)"
+                },
+                {
+                    "description": "",
+                    "name": "CHAINS-GIT_URL",
+                    "value": "$(tasks.git-clone.results.url)"
+                },
+                {
+                    "description": "",
+                    "name": "IMAGE_URL",
+                    "value": "$(tasks.build.results.IMAGE_URL)"
+                },
+                {
+                    "description": "",
+                    "name": "IMAGE_DIGEST",
+                    "value": "$(tasks.build.results.IMAGE_DIGEST)"
+                }
+            ],
+            "tasks": [
+                {
+                    "name": "git-clone",
+                    "params": [
+                        {
+                            "name": "url",
+                            "value": "https://git.test.com"
+                        },
+                        {
+                            "name": "revision",
+                            "value": ""
+                        }
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "git-clone"
+                    }
+                },
+                {
+                    "name": "build",
+                    "params": [
+                        {
+                            "name": "CHAINS-GIT_COMMIT",
+                            "value": "$(tasks.git-clone.results.commit)"
+                        },
+                        {
+                            "name": "CHAINS-GIT_URL",
+                            "value": "$(tasks.git-clone.results.url)"
+                        }
+                    ],
+                    "runAfter": [
+                        "git-clone"
+                    ],
+                    "taskRef": {
+                        "kind": "ClusterTask",
+                        "name": "build"
+                    }
+                }
+            ]
+        },
+        "childReferences": [
+            {
+                "apiVersion": "tekton.dev/v1beta1",
+                "kind": "TaskRun",
+                "name": "git-clone",
+                "pipelineTaskName": "git-clone"
+            },
+            {
+                "apiVersion": "tekton.dev/v1beta1",
+                "kind": "TaskRun",
+                "name": "taskrun-build",
+                "pipelineTaskName": "build"
+            }
+        ]
+    }
+}

--- a/pkg/chains/formats/intotoite6/testdata/taskrun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun1.json
@@ -1,4 +1,7 @@
 {
+    "metadata": {
+        "name": "taskrun-build"
+    },
     "spec": {
         "params": [
             {
@@ -19,7 +22,7 @@
             }
         ],
         "taskRef": {
-            "name": "test-task",
+            "name": "build",
             "kind": "Task"
         },
         "serviceAccountName": "default"
@@ -89,6 +92,17 @@
                 {
                     "name": "BUILDER_IMAGE",
                     "type": "string"
+                }
+            ],
+            "steps": [
+                {
+                    "name": "step1"
+                },
+                {
+                    "name": "step2"
+                },
+                {
+                    "name": "step3"
                 }
             ],
             "results": [

--- a/pkg/chains/formats/intotoite6/testdata/taskrun2.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun2.json
@@ -1,13 +1,18 @@
 {
+    "metadata": {
+        "name": "git-clone"
+    },
     "spec": {
         "params": [],
         "taskRef": {
-            "name": "test-task",
+            "name": "git-clone",
             "kind": "Task"
         },
         "serviceAccountName": "default"
     },
     "status": {
+        "startTime": "2021-03-29T09:50:00Z",
+        "completionTime": "2021-03-29T09:50:15Z",
         "conditions": [
             {
                 "type": "Succeeded",
@@ -36,6 +41,22 @@
             }
         ],
         "taskSpec": {
+            "steps": [
+                {                        
+                    "env": [
+                    {
+                      "name": "HOME",
+                      "value": "$(params.userHome)"
+                    },
+                    {
+                      "name": "PARAM_URL",
+                      "value": "$(params.url)"
+                    }
+                  ],
+                    "name": "step1",
+                    "script": "git clone"
+                }
+            ],
             "params": [],
             "results": [
                 {

--- a/pkg/chains/formats/tekton/tekton.go
+++ b/pkg/chains/formats/tekton/tekton.go
@@ -17,8 +17,7 @@ import (
 	"fmt"
 
 	"github.com/tektoncd/chains/pkg/chains/formats"
-
-	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/chains/pkg/chains/objects"
 )
 
 // Tekton is a formatter that just captures the TaskRun Status with no modifications.
@@ -32,9 +31,9 @@ func NewFormatter() (formats.Payloader, error) {
 // CreatePayload implements the Payloader interface.
 func (i *Tekton) CreatePayload(obj interface{}) (interface{}, error) {
 	switch v := obj.(type) {
-	case *v1beta1.TaskRun:
+	case *objects.TaskRunObject:
 		return v.Status, nil
-	case *v1beta1.PipelineRun:
+	case *objects.PipelineRunObject:
 		return v.Status, nil
 	default:
 		return nil, fmt.Errorf("unsupported type %s", v)

--- a/pkg/chains/formats/tekton/tekton_test.go
+++ b/pkg/chains/formats/tekton/tekton_test.go
@@ -17,6 +17,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/tektoncd/chains/pkg/chains/objects"
 	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
 )
 
@@ -35,7 +36,7 @@ func TestTekton_CreatePayload(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			i := &Tekton{}
-			got, err := i.CreatePayload(tt.tr)
+			got, err := i.CreatePayload(objects.NewTaskRunObject(tt.tr))
 			if err != nil {
 				t.Errorf("Tekton.CreatePayload() error = %v", err)
 				return

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -83,11 +83,12 @@ func (tro *TaskRunObject) GetServiceAccountName() string {
 
 type PipelineRunObject struct {
 	*v1beta1.PipelineRun
+	taskRuns []*v1beta1.TaskRun
 }
 
 func NewPipelineRunObject(pr *v1beta1.PipelineRun) *PipelineRunObject {
 	return &PipelineRunObject{
-		pr,
+		PipelineRun: pr,
 	}
 }
 
@@ -126,4 +127,17 @@ func (pro *PipelineRunObject) GetResults() []Result {
 
 func (pro *PipelineRunObject) GetServiceAccountName() string {
 	return pro.Spec.ServiceAccountName
+}
+
+func (pro *PipelineRunObject) AppendTaskRun(tr *v1beta1.TaskRun) {
+	pro.taskRuns = append(pro.taskRuns, tr)
+}
+
+func (pro *PipelineRunObject) GetTaskRunFromTask(taskName string) *v1beta1.TaskRun {
+	for _, tr := range pro.taskRuns {
+		if tr.Spec.TaskRef.Name == taskName {
+			return tr
+		}
+	}
+	return nil
 }

--- a/pkg/reconciler/pipelinerun/pipelinerun_test.go
+++ b/pkg/reconciler/pipelinerun/pipelinerun_test.go
@@ -16,6 +16,7 @@ package pipelinerun
 import (
 	"context"
 	"testing"
+	"time"
 
 	signing "github.com/tektoncd/chains/pkg/chains"
 	"github.com/tektoncd/chains/pkg/chains/objects"
@@ -27,6 +28,7 @@ import (
 	fakepipelineruninformer "github.com/tektoncd/pipeline/pkg/client/injection/informers/pipeline/v1beta1/pipelinerun/fake"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"knative.dev/pkg/apis"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
@@ -180,6 +182,11 @@ func TestReconciler_handlePipelineRun(t *testing.T) {
 						Name: "taskrun1",
 						Annotations: map[string]string{
 							"chains.tekton.dev/signed": "true",
+						},
+					},
+					Status: v1beta1.TaskRunStatus{
+						TaskRunStatusFields: v1beta1.TaskRunStatusFields{
+							CompletionTime: &v1.Time{Time: time.Date(1995, time.December, 24, 6, 12, 12, 24, time.UTC)},
 						},
 					},
 				},

--- a/vendor/github.com/tektoncd/pipeline/pkg/status/status.go
+++ b/vendor/github.com/tektoncd/pipeline/pkg/status/status.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2022 The Tekton Authors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package status
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1alpha1"
+	"github.com/tektoncd/pipeline/pkg/apis/pipeline/v1beta1"
+	"github.com/tektoncd/pipeline/pkg/client/clientset/versioned"
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// GetTaskRunStatusForPipelineTask takes a minimal embedded status child reference and returns the actual TaskRunStatus
+// for the PipelineTask. It returns an error if the child reference's kind isn't TaskRun.
+func GetTaskRunStatusForPipelineTask(ctx context.Context, client versioned.Interface, ns string, childRef v1beta1.ChildStatusReference) (*v1beta1.TaskRunStatus, error) {
+	if childRef.Kind != "TaskRun" {
+		return nil, fmt.Errorf("could not fetch status for PipelineTask %s: should have kind TaskRun, but is %s", childRef.PipelineTaskName, childRef.Kind)
+	}
+
+	tr, err := client.TektonV1beta1().TaskRuns(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if tr == nil {
+		return nil, nil
+	}
+
+	return &tr.Status, nil
+}
+
+// GetRunStatusForPipelineTask takes a minimal embedded status child reference and returns the actual RunStatus for the
+// PipelineTask. It returns an error if the child reference's kind isn't Run.
+func GetRunStatusForPipelineTask(ctx context.Context, client versioned.Interface, ns string, childRef v1beta1.ChildStatusReference) (*v1alpha1.RunStatus, error) {
+	if childRef.Kind != "Run" {
+		return nil, fmt.Errorf("could not fetch status for PipelineTask %s: should have kind Run, but is %s", childRef.PipelineTaskName, childRef.Kind)
+	}
+
+	r, err := client.TektonV1alpha1().Runs(ns).Get(ctx, childRef.Name, metav1.GetOptions{})
+	if err != nil && !errors.IsNotFound(err) {
+		return nil, err
+	}
+	if r == nil {
+		return nil, nil
+	}
+
+	return &r.Status, nil
+}
+
+// GetFullPipelineTaskStatuses returns populated TaskRun and Run status maps for a PipelineRun from its ChildReferences.
+// If the PipelineRun has no ChildReferences, its .Status.TaskRuns and .Status.Runs will be returned instead.
+func GetFullPipelineTaskStatuses(ctx context.Context, client versioned.Interface, ns string, pr *v1beta1.PipelineRun) (map[string]*v1beta1.PipelineRunTaskRunStatus,
+	map[string]*v1beta1.PipelineRunRunStatus, error) {
+	// If the PipelineRun is nil, just return
+	if pr == nil {
+		return nil, nil, nil
+	}
+
+	// If there are no child references or either TaskRuns or Runs is non-zero, return the existing TaskRuns and Runs maps
+	if len(pr.Status.ChildReferences) == 0 || len(pr.Status.TaskRuns) > 0 || len(pr.Status.Runs) > 0 {
+		return pr.Status.TaskRuns, pr.Status.Runs, nil
+	}
+
+	trStatuses := make(map[string]*v1beta1.PipelineRunTaskRunStatus)
+	runStatuses := make(map[string]*v1beta1.PipelineRunRunStatus)
+
+	for _, cr := range pr.Status.ChildReferences {
+		switch cr.Kind {
+		case "TaskRun":
+			tr, err := client.TektonV1beta1().TaskRuns(ns).Get(ctx, cr.Name, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return nil, nil, err
+			}
+
+			trStatuses[cr.Name] = &v1beta1.PipelineRunTaskRunStatus{
+				PipelineTaskName: cr.PipelineTaskName,
+				WhenExpressions:  cr.WhenExpressions,
+			}
+
+			if tr != nil {
+				trStatuses[cr.Name].Status = &tr.Status
+			}
+		case "Run":
+			r, err := client.TektonV1alpha1().Runs(ns).Get(ctx, cr.Name, metav1.GetOptions{})
+			if err != nil && !errors.IsNotFound(err) {
+				return nil, nil, err
+			}
+
+			runStatuses[cr.Name] = &v1beta1.PipelineRunRunStatus{
+				PipelineTaskName: cr.PipelineTaskName,
+				WhenExpressions:  cr.WhenExpressions,
+			}
+
+			if r != nil {
+				runStatuses[cr.Name].Status = &r.Status
+			}
+		default:
+			// Don't do anything for unknown types.
+		}
+	}
+
+	return trStatuses, runStatuses, nil
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1640,6 +1640,7 @@ github.com/tektoncd/pipeline/pkg/reconciler/events/cloudevent
 github.com/tektoncd/pipeline/pkg/reconciler/pipeline/dag
 github.com/tektoncd/pipeline/pkg/remote
 github.com/tektoncd/pipeline/pkg/remote/oci
+github.com/tektoncd/pipeline/pkg/status
 github.com/tektoncd/pipeline/pkg/substitution
 github.com/tektoncd/pipeline/test
 # github.com/tektoncd/plumbing v0.0.0-20220329085922-d765a5cba75f


### PR DESCRIPTION
Tekton is introducing a change that removes embedded `TaskRun` status' in the `PipelineRun`, instead the TaskRun's will be referenced by a separate field `childReferences`. This change allows the attestation to be generated through both `childReferences` and `taskRuns` fields.