### PR TITLE
Supporting Task's defined within Pipeline

### DIFF
--- a/pkg/chains/formats/intotoite6/testdata/taskrun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun1.json
@@ -1,6 +1,9 @@
 {
     "metadata": {
-        "name": "taskrun-build"
+        "name": "taskrun-build",
+        "labels": {
+            "tekton.dev/pipelineTask": "build"
+        }
     },
     "spec": {
         "params": [

--- a/pkg/chains/formats/intotoite6/testdata/taskrun2.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun2.json
@@ -1,6 +1,9 @@
 {
     "metadata": {
-        "name": "git-clone"
+        "name": "git-clone",
+        "labels": {
+            "tekton.dev/pipelineTask": "git-clone"
+        }
     },
     "spec": {
         "params": [],

--- a/pkg/chains/objects/objects.go
+++ b/pkg/chains/objects/objects.go
@@ -11,6 +11,8 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
+const PipelineTaskLabel = "tekton.dev/pipelineTask"
+
 // Used as a generic Kubernetes object
 // Holds fields common to all objects
 // ref: https://pkg.go.dev/sigs.k8s.io/controller-runtime@v0.9.4/pkg/client#Object
@@ -135,7 +137,8 @@ func (pro *PipelineRunObject) AppendTaskRun(tr *v1beta1.TaskRun) {
 
 func (pro *PipelineRunObject) GetTaskRunFromTask(taskName string) *v1beta1.TaskRun {
 	for _, tr := range pro.taskRuns {
-		if tr.Spec.TaskRef.Name == taskName {
+		val, ok := tr.Labels[PipelineTaskLabel]
+		if ok && val == taskName {
 			return tr
 		}
 	}


### PR DESCRIPTION
Tasks definitions that are embedded in the pipeline break checks that specifically look for the `taskRef` field. This change instead looks for TaskRun's by the `tekton.dev/pipelineTask` label.