### PR TITLE
Support taskRun order in PipelineRun attestation

### DIFF
--- a/pkg/chains/formats/intotoite6/testdata/pipelinerun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/pipelinerun1.json
@@ -101,9 +101,6 @@
                             "value": "$(tasks.git-clone.results.url)"
                         }
                     ],
-                    "runAfter": [
-                        "git-clone"
-                    ],
                     "taskRef": {
                         "kind": "ClusterTask",
                         "name": "build"


### PR DESCRIPTION
Populates the `after` field in the PipelineRun attestation when a task meets one of [the Task ordering rules.](https://tekton.dev/docs/pipelines/pipelines/#configuring-the-task-execution-order)