### PR TITLE
Correctly replacing parameters in attestation

### DIFF
--- a/pkg/chains/formats/intotoite6/intotoite6_test.go
+++ b/pkg/chains/formats/intotoite6/intotoite6_test.go
@@ -74,7 +74,6 @@ func TestTaskRunCreatePayload1(t *testing.T) {
 					"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
 					"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "abcd"},
 					"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
-					"filename":          {Type: "string", StringVal: "/bin/ls"},
 				},
 			},
 			Builder: slsa.ProvenanceBuilder{
@@ -257,8 +256,9 @@ func TestPipelineRunCreatePayload(t *testing.T) {
 						Invocation: slsa.ProvenanceInvocation{
 							ConfigSource: slsa.ConfigSource{},
 							Parameters: map[string]v1beta1.ArrayOrString{
-								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "$(tasks.git-clone.results.commit)"},
-								"CHAINS-GIT_URL":    {Type: "string", StringVal: "$(tasks.git-clone.results.url)"},
+								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "abcd"},
+								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
+								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
 							},
 						},
 						Results: []v1beta1.TaskRunResult{
@@ -442,8 +442,9 @@ func TestPipelineRunCreatePayloadChildRefs(t *testing.T) {
 						Invocation: slsa.ProvenanceInvocation{
 							ConfigSource: slsa.ConfigSource{},
 							Parameters: map[string]v1beta1.ArrayOrString{
-								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "$(tasks.git-clone.results.commit)"},
-								"CHAINS-GIT_URL":    {Type: "string", StringVal: "$(tasks.git-clone.results.url)"},
+								"CHAINS-GIT_COMMIT": {Type: "string", StringVal: "abcd"},
+								"CHAINS-GIT_URL":    {Type: "string", StringVal: "https://git.test.com"},
+								"IMAGE":             {Type: "string", StringVal: "test.io/test/image"},
 							},
 						},
 						Results: []v1beta1.TaskRunResult{
@@ -516,7 +517,10 @@ func TestTaskRunCreatePayload2(t *testing.T) {
 				ID: "test_builder-2",
 			},
 			Invocation: slsa.ProvenanceInvocation{
-				Parameters: map[string]v1beta1.ArrayOrString{},
+				Parameters: map[string]v1beta1.ArrayOrString{
+					"revision": {Type: "string"},
+					"url":      {Type: "string", StringVal: "https://git.test.com"},
+				},
 			},
 			BuildType: "https://tekton.dev/attestations/chains@v2",
 			BuildConfig: taskrun.BuildConfig{

--- a/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
+++ b/pkg/chains/formats/intotoite6/pipelinerun/pipelinerun.go
@@ -79,9 +79,9 @@ func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) Buil
 			continue
 		}
 		steps := []util.StepAttestation{}
-		for i, step := range tr.Status.Steps {
-			stepState := tr.Status.TaskSpec.Steps[i]
-			steps = append(steps, util.AttestStep(&stepState, &step))
+		for i, stepState := range tr.Status.Steps {
+			step := tr.Status.TaskSpec.Steps[i]
+			steps = append(steps, util.AttestStep(&step, &stepState))
 		}
 		after := t.RunAfter
 
@@ -107,7 +107,7 @@ func buildConfig(pro *objects.PipelineRunObject, logger *zap.SugaredLogger) Buil
 		if len(after) == 0 && i >= len(pSpec.Tasks) && last != "" {
 			after = append(after, last)
 		}
-		params := t.Params
+		params := tr.Spec.Params
 		var paramSpecs []v1beta1.ParamSpec
 		if tr.Status.TaskSpec != nil {
 			paramSpecs = tr.Status.TaskSpec.Params

--- a/pkg/chains/formats/intotoite6/testdata/taskrun1.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun1.json
@@ -18,10 +18,6 @@
             {
                 "name": "CHAINS-GIT_URL",
                 "value": "https://git.test.com"
-            },
-            {
-                "name": "filename",
-                "value": "/bin/ls"
             }
         ],
         "taskRef": {

--- a/pkg/chains/formats/intotoite6/testdata/taskrun2.json
+++ b/pkg/chains/formats/intotoite6/testdata/taskrun2.json
@@ -6,7 +6,16 @@
         }
     },
     "spec": {
-        "params": [],
+        "params": [
+            {
+                "name": "url",
+                "value": "https://git.test.com"
+            },
+            {
+                "name": "revision",
+                "value": ""
+            }
+        ],
         "taskRef": {
             "name": "git-clone",
             "kind": "Task"


### PR DESCRIPTION
Adding parameters to the invocation field of the TaskRun attestation by referencing `taskRun.spec.params`. Allows for correct replacement of Tekton variables in the attestation. 